### PR TITLE
Add race-report aggregator (issue #15)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,6 +121,16 @@ python3 cli.py ultra race import-results results.csv --year 2025 --json
 # Analyze peer cohort (finishers near your goal time)
 python3 cli.py ultra race cohort --goal-time "24:00:00" --json
 
+# Race-report aggregator (issue #15): build a research brief for course/strategy intel.
+# The CLI emits the "research order" (sources + queries + output sections); the Claude
+# Code session runs the deep research and files the synthesized guide to race-prep/.
+python3 cli.py ultra race aggregate-reports --json          # structured research brief
+python3 cli.py ultra race aggregate-reports --skeleton      # fillable markdown scaffold
+# After synthesizing, persist the guide to $OBSIDIAN_VAULT_PATH/race-prep/ (stdin or file):
+cat guide.md | python3 cli.py ultra race aggregate-reports --save-guide - \
+  --title "Burning River 100 Course & Strategy Guide" --json
+python3 cli.py ultra race aggregate-reports --save-guide guide.md --date-prefix  # dated snapshot
+
 # Generate A/B/C race execution plans
 python3 cli.py ultra race plan --goal-time "24:00:00" --weather-temp 75 --json
 python3 cli.py ultra race plan --goal-time "24:00:00" --save  # persist to DB

--- a/backend/cli.py
+++ b/backend/cli.py
@@ -27,6 +27,7 @@ from .adapt import (
 )
 from . import strava
 from . import race_engine
+from . import race_research
 from . import vault
 
 
@@ -1699,6 +1700,96 @@ def cmd_race_segments(args):
                   f"{s['avg_grade_pct']:5.1f}% {crew:>4} {drop:>4}")
 
 
+def cmd_race_aggregate_reports(args):
+    """Emit a research brief for BR100 course intel, or persist an agent-synthesized guide.
+
+    Default: print/emit the structured research brief (the "research order"). The
+    deep-research synthesis is performed by the Claude Code session, not here.
+    ``--save-guide PATH|-`` reads a finished markdown guide (file or stdin) and writes it
+    to ``race-prep/`` in the Obsidian vault. ``--skeleton`` emits a fillable markdown
+    scaffold of the output sections.
+    """
+    # --save-guide: persist an agent-produced guide to the vault (no course needed).
+    if args.save_guide:
+        if args.save_guide == "-":
+            body = sys.stdin.read()
+        else:
+            try:
+                with open(args.save_guide, "r", encoding="utf-8") as f:
+                    body = f.read()
+            except OSError as e:
+                _err(f"Could not read guide: {e}", args.json, 2)
+        if not body.strip():
+            _err("Guide is empty — nothing to save.", args.json)
+        try:
+            res = vault.write_race_intel_to_vault(
+                title=args.title or "Burning River 100 Course & Strategy Guide",
+                body=body,
+                doc_type="course-guide",
+                date_prefix=args.date_prefix,
+            )
+        except vault.VaultError as e:
+            _err(str(e), args.json)
+        res["message"] = f"Guide written to {res['path']}"
+        _print(res, args.json)
+        return
+
+    with get_db() as conn:
+        course = race_engine.get_course(conn)
+        if not course:
+            _err("No course loaded. Run: ultra race load-course <gpx> --name ... --year ...",
+                 args.json, 2)
+        course = dict(course)
+        segments = race_engine.get_segments(conn, course["id"])
+        segments_named = any(s.get("name") for s in segments)
+
+    brief = race_research.build_research_brief(
+        course,
+        target_finish=args.goal_time or race_research.DEFAULT_TARGET_FINISH,
+        segments_named=segments_named,
+    )
+
+    if args.skeleton:
+        skeleton = race_research.render_guide_skeleton(brief)
+        if args.json:
+            _print({"skeleton": skeleton}, True)
+        else:
+            print(skeleton)
+        return
+
+    if args.json:
+        _print(brief, True)
+    else:
+        race = brief["race"]
+        print(f"=== {race['name']} ({race['year']}) — Research Brief ===")
+        print(f"{race.get('distance_miles')} mi · {race.get('elevation_gain_ft'):,.0f} ft · "
+              f"{race['race_date']} · target {race['target_finish']}")
+        print()
+        print(brief["objective"])
+        if brief.get("feed_forward"):
+            print()
+            print(f"Feed-forward: {brief['feed_forward']}")
+        print()
+        print("Method:")
+        for i, step in enumerate(brief["method"], 1):
+            print(f"  {i}. {step}")
+        print()
+        print("Sources & queries:")
+        for src in brief["sources"]:
+            print(f"\n  ▸ {src['category']}")
+            print(f"    {src['why']}")
+            print(f"    where: {', '.join(src['where'])}")
+            for query in src["queries"]:
+                print(f"      - {query}")
+        print()
+        print("Output sections:")
+        for section in brief["output_sections"]:
+            print(f"  ▸ {section['heading']} — {section['what']}")
+        print()
+        print("Next: run the research, then "
+              "`ultra race aggregate-reports --save-guide -` to file the guide.")
+
+
 def cmd_export_md(args):
     import os
     from .ultra_plan import generate_training_plan_markdown
@@ -1929,6 +2020,22 @@ def main():
     rst_p = race_sub.add_parser("status", help="Show current race status vs plan")
     rst_p.add_argument("--json", action="store_true")
 
+    # ultra race aggregate-reports
+    rar_p = race_sub.add_parser(
+        "aggregate-reports",
+        help="Build a research brief for BR100 course intel, or save a synthesized guide")
+    rar_p.add_argument("--goal-time", type=str,
+                       help="Target finish time for framing (HH:MM:SS, default 26:00:00)")
+    rar_p.add_argument("--skeleton", action="store_true",
+                       help="Emit a fillable markdown skeleton of the guide sections")
+    rar_p.add_argument("--save-guide", type=str, metavar="PATH",
+                       help="Persist a finished markdown guide to the vault ('-' for stdin)")
+    rar_p.add_argument("--title", type=str,
+                       help="Title for the saved guide (used as the vault filename)")
+    rar_p.add_argument("--date-prefix", action="store_true",
+                       help="Prefix the saved filename with today's date (snapshot mode)")
+    rar_p.add_argument("--json", action="store_true")
+
     # ultra race segments
     rsg_p = race_sub.add_parser("segments", help="View/edit course segments")
     rsg_p.add_argument("--segment", type=int, help="Segment number to edit")
@@ -2009,6 +2116,7 @@ def main():
                 "checkin": cmd_race_checkin,
                 "status": cmd_race_status,
                 "segments": cmd_race_segments,
+                "aggregate-reports": cmd_race_aggregate_reports,
             }
 
             cmd = race_commands.get(args.race_command)

--- a/backend/race_research.py
+++ b/backend/race_research.py
@@ -1,0 +1,237 @@
+"""Race-report aggregator — research-brief builder for BR100 course/strategy intel.
+
+This module embodies the project's agent-driven pattern (see CLAUDE.md): the CLI does
+**not** call an LLM to synthesize the guide. Instead it emits a structured *research
+brief* — a repeatable "research order" grounded in the loaded course — that a Claude Code
+session executes with the deep-research harness (fan-out search → fetch → cross-verify →
+synthesize with citations). The synthesized guide is then persisted to the Obsidian vault
+via ``vault.write_race_intel_to_vault``.
+
+Public functions:
+
+- ``build_research_brief(course, ...)`` — structured brief (sources, queries, output
+  sections, synthesis method) grounded in the course metadata.
+- ``render_guide_skeleton(brief)`` — a markdown skeleton of the output sections, usable
+  as a fallback artifact or a scaffold for the agent to fill.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+# BR100 lives in Cuyahoga Valley National Park / Summit & Cuyahoga counties, NE Ohio,
+# run in late July. These defaults ground weather/region queries when not derivable
+# from the course row.
+DEFAULT_REGION = "Cuyahoga Valley National Park, Summit County, Northeast Ohio"
+DEFAULT_RACE_DATE = "2026-07-26"
+DEFAULT_TARGET_FINISH = "26:00:00"
+
+
+def _source_categories(name: str, year: int) -> list[dict[str, Any]]:
+    """Concrete, grounded search queries per source category from issue #15."""
+    prior = year - 1
+    q = name  # already quoted by callers where needed
+    return [
+        {
+            "category": "Official race site & athlete guide",
+            "why": "Authoritative aid-station list, mile markers, crew-access rules, "
+                   "drop-bag locations, cutoffs, and course map. Highest-trust source.",
+            "where": ["burningriver.run", "westernreserveracingco.com", "ultrasignup.com"],
+            "queries": [
+                f'"{q}" {year} athlete guide',
+                f'"{q}" aid station list crew access drop bags',
+                f'"{q}" course map elevation profile cutoffs',
+                f'"{q}" {year} runner manual',
+            ],
+        },
+        {
+            "category": "Race coverage & results media",
+            "why": "Course narrative, terrain character, and how the race actually plays "
+                   "out near the front and middle of the pack.",
+            "where": ["irunfar.com", "ultrarunning.com", "trailrunnermag.com"],
+            "queries": [
+                f'"{q}" race report',
+                f'"{q}" {prior} results recap',
+                f'"{q}" 100 mile course preview',
+            ],
+        },
+        {
+            "category": "UltraSignup reviews & ratings",
+            "why": "Crowd-sourced difficulty signal and recurring complaints "
+                   "(heat, towpath monotony, night sections, specific climbs).",
+            "where": ["ultrasignup.com"],
+            "queries": [
+                f'"{q}" UltraSignup reviews',
+                f'"{q}" course difficulty review',
+            ],
+        },
+        {
+            "category": "Reddit r/ultrarunning trip reports",
+            "why": "Candid, recent first-person failure modes and pacing/fueling lessons.",
+            "where": ["reddit.com/r/ultrarunning", "reddit.com/r/trailrunning"],
+            "queries": [
+                f'"{q}" site:reddit.com race report',
+                f"{q} reddit trip report DNF",
+                f"{q} reddit heat humidity night",
+            ],
+        },
+        {
+            "category": "Personal blogs & race reports",
+            "why": "Segment-by-segment narrative, drop-bag contents, crew logistics, and "
+                   "the insider notes runners wish they'd had.",
+            "where": ["blogspot.com", "wordpress.com", "medium.com", "strava.com"],
+            "queries": [
+                f'"{q}" 100 race report blog',
+                f'"{q}" pacing strategy crew plan',
+                f'"{q}" first 100 miler report',
+            ],
+        },
+        {
+            "category": "YouTube race recaps & course previews",
+            "why": "Visual terrain reconnaissance for the major climbs, towpath/road "
+                   "stretches, and night sections.",
+            "where": ["youtube.com"],
+            "queries": [
+                f'"{q}" race recap',
+                f'"{q}" course preview',
+                f'"{q}" 100 miler vlog',
+            ],
+        },
+        {
+            "category": "Late-July NE Ohio weather history",
+            "why": "Heat/humidity and overnight-low patterns drive fueling, sodium, "
+                   "and night-kit decisions — and BR's signature mid-pack failure mode.",
+            "where": ["weather.gov", "wunderground.com", "weatherspark.com"],
+            "queries": [
+                f"{DEFAULT_REGION} late July temperature humidity dew point history",
+                "Akron Ohio July 26 average high low temperature dew point",
+                "Cuyahoga Valley July heat index overnight low historical",
+            ],
+        },
+    ]
+
+
+def _output_sections() -> list[dict[str, str]]:
+    """The sections the synthesized guide must contain (issue #15 Output)."""
+    return [
+        {"heading": "Race Overview",
+         "what": "Distance, total climb, terrain mix (towpath/road vs singletrack), "
+                 "start time, time limit, and key cutoffs."},
+        {"heading": "Aid Station Table",
+         "what": "Every aid station: name, mile, distance from previous, climb between "
+                 "stations, crew access (Y/N), drop bag (Y/N), pacer rules."},
+        {"heading": "Crew & Drop-Bag Logistics",
+         "what": "Which stations crew can reach, parking/access notes, drive times "
+                 "between crew points, and recommended drop-bag placement."},
+        {"heading": "Course Sections & Terrain",
+         "what": "Section-by-section character — the major climbs, the towpath/road "
+                 "stretches, technical singletrack, and where the runnable miles are."},
+        {"heading": "Common Failure Points",
+         "what": "Where runners blow up: major climbs, late-July heat/humidity, the "
+                 "night sections, low patches, and the towpath/road monotony."},
+        {"heading": "Weather Patterns (late July)",
+         "what": "Typical highs/lows, dew point/humidity, overnight conditions, and "
+                 "storm risk — with the gear and fueling implications."},
+        {"heading": "Gear & Drop-Bag Implications",
+         "what": "Night kit (lights, layers), heat management, shoe/sock strategy for "
+                 "towpath vs trail, and what to stage in each drop bag."},
+        {"heading": "Course-Knowledge Notes",
+         "what": "The insider tips runners say they wish they'd had — landmark cues, "
+                 "where to bank time, where to hold back."},
+        {"heading": "Sources & Confidence",
+         "what": "Cited source URLs, plus explicit flags for single-source or "
+                 "contradictory claims and any gaps the research could not close."},
+    ]
+
+
+def _method() -> list[str]:
+    """Deep-research harness steps the executing agent should follow."""
+    return [
+        "Fan out web searches across every source category below (use the queries verbatim, then iterate).",
+        "Fetch the highest-signal pages first: the official athlete guide, recent race reports, UltraSignup reviews.",
+        "Cross-verify every aid-station name / mile / crew flag against >=2 independent sources; flag single-source claims.",
+        "Synthesize into the output sections; cite each non-obvious claim with its source URL inline.",
+        "Call out contradictions, stale (pre-reroute) course info, and gaps explicitly — do not paper over uncertainty.",
+        "Save the finished guide to the vault: `ultra race aggregate-reports --save-guide -` (markdown on stdin).",
+    ]
+
+
+def build_research_brief(
+    course: dict,
+    *,
+    race_date: str | None = None,
+    target_finish: str = DEFAULT_TARGET_FINISH,
+    segments_named: bool | None = None,
+) -> dict[str, Any]:
+    """Build a structured research brief grounded in the loaded course.
+
+    ``course`` is a row dict from ``race_engine.get_course`` (keys: name, year,
+    total_distance_miles, total_elevation_gain_ft). ``segments_named`` lets the caller
+    flag that the loaded segments still lack aid-station names so the brief can note the
+    feed-forward into ``race segments`` (and the crew manual, issue #12).
+    """
+    name = course["name"]
+    year = course["year"]
+
+    brief: dict[str, Any] = {
+        "race": {
+            "name": name,
+            "year": year,
+            "race_date": race_date or DEFAULT_RACE_DATE,
+            "region": DEFAULT_REGION,
+            "distance_miles": course.get("total_distance_miles"),
+            "elevation_gain_ft": course.get("total_elevation_gain_ft"),
+            "target_finish": target_finish,
+        },
+        "objective": (
+            f"Gather all available public {name} intel and synthesize one comprehensive "
+            f"course/strategy guide (target finish {target_finish}). Output feeds the "
+            "capstone race-strategy report (issue #16) and can populate aid-station names, "
+            "crew flags, and drop-bag data for `race segments` / the crew manual (issue #12)."
+        ),
+        "method": _method(),
+        "sources": _source_categories(name, year),
+        "output_sections": _output_sections(),
+    }
+
+    if segments_named is False:
+        brief["feed_forward"] = (
+            "The loaded course segments are unnamed and have no crew/drop-bag flags. "
+            "Capture the aid-station name + mile + crew/drop-bag for each station so they "
+            "can be written back via `ultra race segments --segment N --set-name ... "
+            "--crew 1 --drop-bag 1`."
+        )
+
+    return brief
+
+
+def render_guide_skeleton(brief: dict[str, Any]) -> str:
+    """Render a markdown skeleton of the guide's output sections.
+
+    Useful as a fallback artifact or a scaffold the agent fills in. The real content is
+    produced by the deep-research pass, not by this function.
+    """
+    race = brief["race"]
+    lines: list[str] = []
+    lines.append(f"# {race['name']} — Course & Strategy Guide")
+    lines.append("")
+    dist = race.get("distance_miles")
+    gain = race.get("elevation_gain_ft")
+    meta_bits = [f"{race['year']}", race.get("region", "")]
+    if dist:
+        meta_bits.append(f"{dist:g} mi")
+    if gain:
+        meta_bits.append(f"{gain:,.0f} ft climb")
+    meta_bits.append(f"target {race.get('target_finish')}")
+    lines.append("*" + " · ".join(b for b in meta_bits if b) + "*")
+    lines.append("")
+    lines.append("> Skeleton only — fill each section from the research brief "
+                 "(`ultra race aggregate-reports --json`).")
+    lines.append("")
+    for section in brief["output_sections"]:
+        lines.append(f"## {section['heading']}")
+        lines.append("")
+        lines.append(f"_{section['what']}_")
+        lines.append("")
+    return "\n".join(lines).rstrip() + "\n"

--- a/backend/vault.py
+++ b/backend/vault.py
@@ -25,6 +25,7 @@ from typing import Any
 
 OJ_BINARY = "/home/michaelpawlus/projects/obsidian_journal/.venv/bin/oj"
 WORKOUTS_SUBDIR = "workouts"
+RACE_PREP_SUBDIR = "race-prep"
 PRODUCT_LOG_FILENAME = "PRODUCT_LOG.md"
 JOURNAL_SUBDIR = "Journal"
 
@@ -58,6 +59,12 @@ def _vault_root() -> Path:
 
 def _workouts_dir() -> Path:
     out = _vault_root() / WORKOUTS_SUBDIR
+    out.mkdir(parents=True, exist_ok=True)
+    return out
+
+
+def _race_prep_dir() -> Path:
+    out = _vault_root() / RACE_PREP_SUBDIR
     out.mkdir(parents=True, exist_ok=True)
     return out
 
@@ -407,3 +414,80 @@ def append_product_log_entry(
         f.write(entry)
 
     return {"path": str(log_path), "appended": True}
+
+
+def _race_frontmatter(doc_date: str, doc_type: str) -> str:
+    tag = re.sub(r"[^a-z0-9]+", "-", (doc_type or "guide").lower()).strip("-") or "guide"
+    return (
+        "---\n"
+        f"date: '{doc_date}'\n"
+        "tags:\n"
+        "- race-prep\n"
+        f"- race-prep/{tag}\n"
+        "type: race-intel\n"
+        "---\n\n"
+    )
+
+
+def write_race_intel_to_vault(
+    *,
+    title: str,
+    body: str,
+    doc_date: str | None = None,
+    doc_type: str = "course-guide",
+    date_prefix: bool = False,
+    use_oj: bool = False,
+) -> dict:
+    """Render a race-intel document and write it to ``race-prep/`` in the Obsidian vault.
+
+    Used for synthesized course/strategy guides (issue #15) and other BR100 prep docs
+    that feed the capstone strategy report. Unlike run reports, these are typically
+    regenerated in place, so the filename defaults to a stable ``<Title>.md`` (set
+    ``date_prefix=True`` for a dated, point-in-time snapshot instead).
+
+    Defaults to a direct write so the ``race-prep`` frontmatter tags are applied
+    deterministically (these are reference docs, not journal entries); pass
+    ``use_oj=True`` to route through the ``oj`` CLI instead. ``body`` is the markdown
+    the agent synthesized — this function only frames and persists it.
+
+    Returns ``{"path": <absolute md path>, "method": "oj"|"direct", "filename": ...}``.
+    Raises ``VaultError`` if the vault path itself is unusable.
+    """
+    race_prep_dir = _race_prep_dir()  # raises VaultError if env unset/missing
+
+    doc_date = doc_date or datetime.now().strftime("%Y-%m-%d")
+    # Preserve the author's casing (e.g. "BR100"); only strip filesystem-illegal chars.
+    title_segment = re.sub(r"[\\/:*?\"<>|]", "", (title or "").strip()) or "Race Intel"
+    title_segment = re.sub(r"\s+", " ", title_segment)
+    stem = f"{doc_date} {title_segment}" if date_prefix else title_segment
+    filename = stem.strip() + ".md"
+    target = race_prep_dir / filename
+
+    framed = _race_frontmatter(doc_date, doc_type) + body.rstrip() + "\n"
+
+    if use_oj:
+        ok, journal_path = _try_oj_capture(body)
+        if ok:
+            src: Path | None = None
+            if journal_path:
+                jp = Path(journal_path)
+                if jp.exists():
+                    src = jp
+            if src is None:
+                journal_dir = _vault_root() / JOURNAL_SUBDIR
+                if journal_dir.exists():
+                    candidates = sorted(
+                        journal_dir.glob("*.md"),
+                        key=lambda p: p.stat().st_mtime,
+                        reverse=True,
+                    )
+                    if candidates:
+                        src = candidates[0]
+            if src and src.exists():
+                target.parent.mkdir(parents=True, exist_ok=True)
+                shutil.move(str(src), str(target))
+                return {"path": str(target), "method": "oj", "filename": filename}
+            # oj said ok but we can't find the note — fall through to direct write.
+
+    target.write_text(framed, encoding="utf-8")
+    return {"path": str(target), "method": "direct", "filename": filename}


### PR DESCRIPTION
Closes #15.

## What

New `ultra race aggregate-reports` command that aggregates public BR100 course/strategy intel into a comprehensive guide — following the project's agent-driven pattern: the CLI builds the *research order*, the Claude Code session runs the deep research and synthesizes.

- **`backend/race_research.py`** (new) — `build_research_brief()` emits a structured brief grounded in the loaded course (7 source categories with concrete queries, 9 output sections, deep-research method steps, feed-forward note flagging the unnamed segments); `render_guide_skeleton()` renders a fillable scaffold.
- **`backend/vault.py`** — `write_race_intel_to_vault()` writes to a new **`race-prep/`** vault subfolder with deterministic `race-prep` frontmatter (direct write by default, `oj` optional).
- **`backend/cli.py`** — `cmd_race_aggregate_reports` + subparser + dispatch: `--json` / `--skeleton` / `--save-guide PATH|-` / `--title` / `--date-prefix`.
- **`CLAUDE.md`** — documented in the Race Day CLI Reference.

## Delivered guide

Ran a full deep-research pass and filed *Burning River 100 Course & Strategy Guide* to `race-prep/`. Cross-verified against the official 2025 WRR Participant Guide (incl. the aid-station overview extracted from the guide's image table), finisher reports, and climatology:

- Full **aid-station table** (out-and-back, 23 stations, miles / open-close / drop-bag / crew), 4:00 AM start, **30-hour cutoff**.
- Crew-accessible set, drop-bag + headlamp-bucket locations.
- Terrain breakdown, three-thirds framing, exposed Bike & Hike heat crucible (~mi 45–55), late-race GI/foot/night failure points, late-July NE-Ohio weather, gear/drop-bag staging, insider pacing notes.
- Confidence flags: elevation 9k (official copy) vs 10,568 ft (2026 V2 GPX); aid data is 2025 — re-pull the 2026 athlete guide before locking the crew sheet.

Feeds the crew manual (#12) and capstone strategy report (#16); the crew/drop-bag/mile data can populate the currently-unnamed `race segments`.

## Test plan

- `python3 -m pytest backend/tests/` → 12 passed.
- Smoke-tested all four command paths (brief human/JSON, skeleton, save-guide via stdin + file); verified the vault file lands in `race-prep/` with correct frontmatter and preserved title casing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)