### PR TITLE
Add historical analysis CLI: learn from the athlete's own prior races

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,8 +115,21 @@ python3 cli.py ultra race load-course course.gpx --name "BR100" --year 2026 \
 python3 cli.py ultra race segments --json
 python3 cli.py ultra race segments --segment 3 --set-name "Happy Days 1" --crew 1 --drop-bag 1
 
-# Import historical race results from CSV
+# Import historical race results from CSV (peer finishers on this course)
 python3 cli.py ultra race import-results results.csv --year 2025 --json
+
+# Historical analysis of the athlete's OWN prior races at the same distance.
+# Extracts late fade / positive split / HR drift / stoppage and feeds the
+# lessons into coaching (run reports), programming (training implications),
+# and race reports (late-race fade biases the Race Day Engine pace plan).
+python3 cli.py ultra race history --seed              # seed known prior 100s
+python3 cli.py ultra race history --json              # analyze all prior races
+python3 cli.py ultra race history --distance-filter 100   # only same-distance efforts
+python3 cli.py ultra race history --md                # markdown report (for the vault)
+# Add a race manually, optionally enriching from Strava when connected:
+python3 cli.py ultra race history --add --name "Tunnel Hill 100" --date 2021-11-13 \
+  --distance 101.1 --finish 25:23:00 --moving 23:34:00 \
+  --first-half 13:03:00 --second-half 14:56:00 --strava-id 6257195830
 
 # Analyze peer cohort (finishers near your goal time)
 python3 cli.py ultra race cohort --goal-time "24:00:00" --json

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ DEVICE SYNC      ▶  strava-{connect, status, import}
 
 RACE DAY         ▶  race {load-course, cohort, plan, nutrition,
                           crew-sheet, checkin, status, segments,
-                          import-results}
+                          import-results, history}
 
 EXPORT           ▶  plan --export-md
 
@@ -194,12 +194,13 @@ Every command in `backend/cli.py` appears in exactly one block below. Examples u
 </details>
 
 <details>
-<summary><b>Race day</b> · load-course  import-results  cohort  plan  nutrition  crew-sheet  checkin  status  segments</summary>
+<summary><b>Race day</b> · load-course  import-results  history  cohort  plan  nutrition  crew-sheet  checkin  status  segments</summary>
 
 | Command | What it does | Example |
 |---|---|---|
 | `ultra ultra race load-course` | Load a race course from a GPX file. Optionally pass `--segment-breaks` to define aid-station mile markers. | `ultra ultra race load-course course.gpx --name "BR100" --year 2026` |
 | `ultra ultra race import-results` | Import historical finisher splits from CSV for peer-cohort analysis. | `ultra ultra race import-results results.csv --year 2025` |
+| `ultra ultra race history` | Ingest & analyze the athlete's *own* prior races at the same distance (late fade, positive split, HR drift, stoppage). Feeds coaching, training implications, and the Race Day Engine's late-race fade. `--seed`, `--add`, `--json`, `--md`. | `ultra ultra race history --seed && ultra ultra race history --distance-filter 100` |
 | `ultra ultra race cohort` | Build a peer cohort of historical finishers near a goal time. | `ultra ultra race cohort --goal-time 24:00:00 --json` |
 | `ultra ultra race plan` | Generate A / B / C race execution plans (pace + fueling) given a goal time and weather. `--save` persists to the DB. | `ultra ultra race plan --goal-time 24:00:00 --weather-temp 75 --save` |
 | `ultra ultra race nutrition` | Per-segment fueling plan (carbs/hr, sodium/hr, what goes in each drop bag). | `ultra ultra race nutrition --goal-time 24:00:00` |

--- a/backend/cli.py
+++ b/backend/cli.py
@@ -332,6 +332,23 @@ def _submit_run(distance, duration=None, hr=None, max_hr=None, elevation=None,
         current_targets = get_current_targets(conn, plan["id"])
         targets_dict = dict(current_targets) if current_targets else None
 
+        # Prior-race lessons (athlete's own 100s) to calibrate coaching.
+        historical_summary = None
+        try:
+            from . import historical
+            hist = historical.analyze_history(conn, target_distance=100)
+            if hist.get("count"):
+                historical_summary = {
+                    "prior_races": hist["count"],
+                    "failure_mode": hist.get("failure_mode"),
+                    "avg_fade_pct": hist.get("avg_fade_pct"),
+                    "positive_split_count": hist.get("positive_split_count"),
+                    "lessons": hist.get("lessons"),
+                    "training_implications": hist.get("training_implications"),
+                }
+        except Exception:
+            historical_summary = None
+
     nutrition_data = None
     if any(v is not None for v in (pre_meal, during_fuel, during_hydration, post_meal, nutrition_notes)):
         nutrition_data = {
@@ -345,7 +362,7 @@ def _submit_run(distance, duration=None, hr=None, max_hr=None, elevation=None,
     try:
         if not as_json:
             print("Analyzing run...", file=sys.stderr)
-        feedback = analyze_run_feedback(prescribed, actual, weekly_context, trend_data, benchmark_data, race_info, athlete_targets=targets_dict, nutrition_data=nutrition_data)
+        feedback = analyze_run_feedback(prescribed, actual, weekly_context, trend_data, benchmark_data, race_info, athlete_targets=targets_dict, nutrition_data=nutrition_data, historical_data=historical_summary)
     except Exception as e:
         feedback = {
             "compliance_score": None,
@@ -1460,6 +1477,105 @@ def cmd_race_cohort(args):
                       f"{s['pace_stdev_seconds'] or 0:6.0f}s{danger}")
 
 
+def cmd_race_history(args):
+    """Ingest & analyze the athlete's own prior races at a given distance."""
+    from . import historical
+
+    with get_db() as conn:
+        # --- mutations ---------------------------------------------------
+        if args.seed:
+            n = historical.seed_known_races(conn)
+            if not (args.json or args.add or args.strava_id):
+                print(f"Seeded {n} known prior races.", file=sys.stderr)
+
+        if args.add:
+            if not args.name or not args.date:
+                _err("--add requires --name and --date", args.json, 2)
+            race_id = historical.add_race(
+                conn,
+                name=args.name,
+                race_date=args.date,
+                distance_miles=args.distance,
+                elevation_gain_ft=args.elevation,
+                finish_time_seconds=race_engine._parse_time(args.finish) if args.finish else None,
+                moving_time_seconds=race_engine._parse_time(args.moving) if args.moving else None,
+                first_half_seconds=race_engine._parse_time(args.first_half) if args.first_half else None,
+                second_half_seconds=race_engine._parse_time(args.second_half) if args.second_half else None,
+                avg_hr=args.avg_hr,
+                terrain=args.terrain,
+                dnf=args.dnf,
+                strava_activity_id=args.strava_id,
+                notes=args.notes,
+            )
+            if not args.json:
+                print(f"Saved race id {race_id}: {args.name}", file=sys.stderr)
+            if args.strava_id:
+                try:
+                    filled = historical.enrich_from_strava(conn, race_id, args.strava_id)
+                    if not args.json:
+                        print(f"Enriched from Strava: {', '.join(filled)}", file=sys.stderr)
+                except Exception as e:
+                    if not args.json:
+                        print(f"Strava enrich skipped: {e}", file=sys.stderr)
+
+        elif args.strava_id and args.race_id:
+            try:
+                filled = historical.enrich_from_strava(conn, args.race_id, args.strava_id)
+                if not args.json:
+                    print(f"Enriched race {args.race_id}: {', '.join(filled)}", file=sys.stderr)
+            except Exception as e:
+                _err(f"Strava enrich failed: {e}", args.json, 1)
+
+        # --- analysis ----------------------------------------------------
+        analysis = historical.analyze_history(
+            conn, target_distance=args.distance_filter,
+            tolerance_pct=args.tolerance,
+        )
+
+        if args.output or args.md:
+            md = historical.history_to_markdown(analysis)
+            if args.output:
+                with open(args.output, "w") as f:
+                    f.write(md)
+                if not args.json:
+                    print(f"Wrote report to {args.output}", file=sys.stderr)
+            else:
+                print(md)
+                return
+
+    if args.json:
+        _print(analysis, True)
+        return
+
+    if not analysis.get("count"):
+        print(analysis.get("message", "No prior races on file."))
+        return
+
+    print("=== Historical Race Analysis ===")
+    if analysis.get("failure_mode"):
+        print(f"Dominant failure mode: {analysis['failure_mode']}")
+    if analysis.get("avg_fade_pct") is not None:
+        print(f"Average late-race fade: {analysis['avg_fade_pct']}%  "
+              f"({analysis['positive_split_count']}/{analysis['count']} positive splits)")
+    print()
+    print(f"{'Race':<22} {'Date':<11} {'Dist':>5} {'Finish':>9} {'Fade':>6} {'Pace':>9}")
+    print("-" * 70)
+    for r in analysis["races"]:
+        fade = f"+{r['fade_pct']}%" if r.get("fade_pct") is not None else "—"
+        finish = r.get("finish_time") or ("DNF" if r["dnf"] else "—")
+        pace = r.get("avg_pace_display") or "—"
+        print(f"{r['name']:<22} {r['race_date']:<11} {r['distance_miles'] or 0:5.1f} "
+              f"{finish:>9} {fade:>6} {pace:>9}")
+    if analysis.get("lessons"):
+        print("\nLessons:")
+        for l in analysis["lessons"]:
+            print(f"  • {l}")
+    if analysis.get("training_implications"):
+        print("\nTraining implications:")
+        for i in analysis["training_implications"]:
+            print(f"  • {i}")
+
+
 def cmd_race_plan(args):
     goal_seconds = race_engine._parse_time(args.goal_time)
     with get_db() as conn:
@@ -1884,6 +2000,37 @@ def main():
                        help="Course name to associate results with")
     rir_p.add_argument("--json", action="store_true")
 
+    # ultra race history
+    rhi_p = race_sub.add_parser(
+        "history",
+        help="Ingest & analyze the athlete's own prior races (same-distance lessons)")
+    rhi_p.add_argument("--seed", action="store_true",
+                       help="Seed the known prior 100s (idempotent)")
+    rhi_p.add_argument("--add", action="store_true", help="Add/update a race")
+    rhi_p.add_argument("--name", type=str, help="Race name (with --add)")
+    rhi_p.add_argument("--date", type=str, help="Race date YYYY-MM-DD (with --add)")
+    rhi_p.add_argument("--distance", type=float, help="Distance in miles (with --add)")
+    rhi_p.add_argument("--elevation", type=float, help="Elevation gain in feet (with --add)")
+    rhi_p.add_argument("--finish", type=str, help="Finish (elapsed) time HH:MM:SS (with --add)")
+    rhi_p.add_argument("--moving", type=str, help="Moving time HH:MM:SS (with --add)")
+    rhi_p.add_argument("--first-half", type=str, help="First-half split HH:MM:SS (with --add)")
+    rhi_p.add_argument("--second-half", type=str, help="Second-half split HH:MM:SS (with --add)")
+    rhi_p.add_argument("--avg-hr", type=int, help="Average heart rate (with --add)")
+    rhi_p.add_argument("--terrain", type=str, help="Terrain notes (with --add)")
+    rhi_p.add_argument("--dnf", action="store_true", help="Mark as DNF (with --add)")
+    rhi_p.add_argument("--notes", type=str, help="Notes (with --add)")
+    rhi_p.add_argument("--strava-id", type=int,
+                       help="Strava activity id to enrich from (with --add, or --race-id)")
+    rhi_p.add_argument("--race-id", type=int,
+                       help="Existing athlete_races id to enrich via --strava-id")
+    rhi_p.add_argument("--distance-filter", type=float,
+                       help="Only analyze races near this distance (miles)")
+    rhi_p.add_argument("--tolerance", type=float, default=15.0,
+                       help="Distance match tolerance percent (default 15)")
+    rhi_p.add_argument("--md", action="store_true", help="Print markdown report")
+    rhi_p.add_argument("--output", type=str, help="Write markdown report to a file path")
+    rhi_p.add_argument("--json", action="store_true")
+
     # ultra race cohort
     rco_p = race_sub.add_parser("cohort", help="Analyze peer cohort from historical results")
     rco_p.add_argument("--goal-time", type=str, required=True,
@@ -2002,6 +2149,7 @@ def main():
             race_commands = {
                 "load-course": cmd_race_load_course,
                 "import-results": cmd_race_import_results,
+                "history": cmd_race_history,
                 "cohort": cmd_race_cohort,
                 "plan": cmd_race_plan,
                 "nutrition": cmd_race_nutrition,

--- a/backend/database.py
+++ b/backend/database.py
@@ -288,6 +288,30 @@ def init_db():
                 actual_elapsed_seconds INTEGER,
                 notes TEXT
             );
+
+            -- Athlete's OWN prior races (benchmark efforts across courses),
+            -- used by historical analysis to calibrate the plan. Distinct from
+            -- historical_results, which holds peer finishers on a single course.
+            CREATE TABLE IF NOT EXISTS athlete_races (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                name TEXT NOT NULL,
+                race_date TEXT NOT NULL,
+                distance_miles REAL,
+                elevation_gain_ft REAL,
+                finish_time_seconds INTEGER,
+                moving_time_seconds INTEGER,
+                first_half_seconds INTEGER,
+                second_half_seconds INTEGER,
+                avg_hr INTEGER,
+                first_half_hr INTEGER,
+                second_half_hr INTEGER,
+                terrain TEXT,
+                dnf INTEGER NOT NULL DEFAULT 0,
+                strava_activity_id INTEGER,
+                notes TEXT,
+                created_at TEXT NOT NULL DEFAULT (datetime('now')),
+                UNIQUE(name, race_date)
+            );
         """)
 
         # Migrate CHECK constraints if DB predates ultra plan support

--- a/backend/historical.py
+++ b/backend/historical.py
@@ -1,0 +1,448 @@
+"""Historical analysis — ingest & learn from the athlete's OWN prior races.
+
+Unlike ``race_engine``'s ``historical_results`` (peer finishers on a single
+course, keyed to course geometry), this module models the athlete's own prior
+efforts at a given distance — across different courses — as benchmark efforts.
+It extracts the signals that calibrate the BR100 plan: late-race fade, the
+positive split, HR drift, and stoppage (elapsed-vs-moving) time.
+
+These lessons feed three places:
+  - coaching     (run-report feedback via ``analyze_run_feedback``)
+  - programming  (training implications surfaced in the analysis)
+  - race reports (historical fade blended into the Race Day Engine pace plan)
+
+Storage lives in the ``athlete_races`` table (see ``database.py``). Data is
+entered manually / seeded from known efforts, and optionally enriched from
+Strava when connected.
+"""
+
+import statistics
+
+from .race_engine import _parse_time, _format_time, _format_pace
+
+
+# ---------------------------------------------------------------------------
+# Known prior 100s (from issue #13). Seedable so the analysis works offline,
+# before any Strava pull. Times are stored as seconds.
+# ---------------------------------------------------------------------------
+
+KNOWN_RACES = [
+    {
+        "name": "Tunnel Hill 100",
+        "race_date": "2021-11-13",
+        "distance_miles": 101.1,
+        "elevation_gain_ft": 1900,
+        "finish_time_seconds": _parse_time("25:23:00"),
+        "moving_time_seconds": _parse_time("23:34:00"),
+        "first_half_seconds": _parse_time("13:03:00"),
+        "second_half_seconds": _parse_time("14:56:00"),
+        "avg_hr": None,
+        "terrain": "flat (crushed limestone rail-trail)",
+        "dnf": 0,
+        "strava_activity_id": 6257195830,
+        "notes": "PR. Smallest fade of any 100 — the pacing template.",
+    },
+    {
+        "name": "Wolverine State 100",
+        "race_date": "2025-10-11",
+        "distance_miles": 102.8,
+        "elevation_gain_ft": 5049,
+        "finish_time_seconds": _parse_time("27:17:00"),
+        "moving_time_seconds": None,
+        "first_half_seconds": _parse_time("14:06:00"),
+        "second_half_seconds": _parse_time("17:42:00"),
+        "avg_hr": 122,
+        "terrain": "hilly loop course",
+        "dnf": 0,
+        "strava_activity_id": 16121062071,
+        "notes": "Heavy late walking; avg HR only 122 — aerobically capable, "
+                 "limited by late-race discipline, not fitness.",
+    },
+    {
+        "name": "Canal Corridor 100",
+        "race_date": "2023-10-07",
+        "distance_miles": 76.8,
+        "elevation_gain_ft": 900,
+        "finish_time_seconds": None,
+        "moving_time_seconds": None,
+        "first_half_seconds": _parse_time("12:08:00"),
+        "second_half_seconds": _parse_time("15:48:00"),
+        "avg_hr": None,
+        "terrain": "flat canal towpath",
+        "dnf": 1,
+        "strava_activity_id": 10003645304,
+        "notes": "Weather-derailed walk-in. Went out hot, overnight storms. "
+                 "Worst fade — mental, not just physical.",
+    },
+    {
+        "name": "OBU 90",
+        "race_date": "2025-03-22",
+        "distance_miles": 90.2,
+        "elevation_gain_ft": None,
+        "finish_time_seconds": _parse_time("22:04:00"),
+        "moving_time_seconds": None,
+        "first_half_seconds": None,
+        "second_half_seconds": None,
+        "avg_hr": None,
+        "terrain": None,
+        "dnf": 0,
+        "strava_activity_id": 13967459991,
+        "notes": "Strong finish; no half-split on file.",
+    },
+]
+
+_FIELDS = (
+    "name", "race_date", "distance_miles", "elevation_gain_ft",
+    "finish_time_seconds", "moving_time_seconds", "first_half_seconds",
+    "second_half_seconds", "avg_hr", "first_half_hr", "second_half_hr",
+    "terrain", "dnf", "strava_activity_id", "notes",
+)
+
+
+# ---------------------------------------------------------------------------
+# Storage
+# ---------------------------------------------------------------------------
+
+def add_race(conn, **fields):
+    """Insert (or replace, by name+date) one athlete race. Returns row id."""
+    row = {f: fields.get(f) for f in _FIELDS}
+    if not row.get("name") or not row.get("race_date"):
+        raise ValueError("name and race_date are required")
+    row["dnf"] = 1 if row.get("dnf") else 0
+
+    existing = conn.execute(
+        "SELECT id FROM athlete_races WHERE name = ? AND race_date = ?",
+        (row["name"], row["race_date"]),
+    ).fetchone()
+
+    cols = list(_FIELDS)
+    vals = [row[c] for c in cols]
+    if existing:
+        assignments = ", ".join(f"{c} = ?" for c in cols)
+        conn.execute(
+            f"UPDATE athlete_races SET {assignments} WHERE id = ?",
+            (*vals, existing["id"]),
+        )
+        return existing["id"]
+    placeholders = ", ".join("?" for _ in cols)
+    cur = conn.execute(
+        f"INSERT INTO athlete_races ({', '.join(cols)}) VALUES ({placeholders})",
+        vals,
+    )
+    return cur.lastrowid
+
+
+def seed_known_races(conn):
+    """Seed the known prior 100s. Idempotent (keyed on name+date). Returns count."""
+    for race in KNOWN_RACES:
+        add_race(conn, **race)
+    return len(KNOWN_RACES)
+
+
+def get_races(conn, target_distance=None, tolerance_pct=15.0, include_dnf=True):
+    """Return athlete races, optionally filtered to a target distance.
+
+    ``target_distance`` keeps only races within ``tolerance_pct`` percent of the
+    given distance — i.e. "any prior races of the same distance".
+    """
+    rows = conn.execute(
+        "SELECT * FROM athlete_races ORDER BY race_date"
+    ).fetchall()
+    races = [dict(r) for r in rows]
+
+    if not include_dnf:
+        races = [r for r in races if not r["dnf"]]
+
+    if target_distance is not None:
+        lo = target_distance * (1 - tolerance_pct / 100)
+        hi = target_distance * (1 + tolerance_pct / 100)
+        races = [r for r in races
+                 if r["distance_miles"] and lo <= r["distance_miles"] <= hi]
+
+    return races
+
+
+# ---------------------------------------------------------------------------
+# Metrics
+# ---------------------------------------------------------------------------
+
+def race_metrics(race):
+    """Compute derived metrics for one race: fade, split, HR drift, stoppage."""
+    m = {
+        "fade_pct": None,
+        "positive_split": None,
+        "hr_drift_bpm": None,
+        "stoppage_seconds": None,
+        "stoppage_pct": None,
+        "avg_pace_seconds": None,
+        "avg_pace_display": None,
+    }
+
+    fh, sh = race.get("first_half_seconds"), race.get("second_half_seconds")
+    if fh and sh and fh > 0:
+        m["fade_pct"] = round(((sh - fh) / fh) * 100, 1)
+        m["positive_split"] = sh > fh
+
+    fhr, shr = race.get("first_half_hr"), race.get("second_half_hr")
+    if fhr and shr:
+        m["hr_drift_bpm"] = shr - fhr
+
+    finish = race.get("finish_time_seconds")
+    moving = race.get("moving_time_seconds")
+    if finish and moving and finish >= moving:
+        m["stoppage_seconds"] = finish - moving
+        m["stoppage_pct"] = round((finish - moving) / finish * 100, 1)
+
+    dist = race.get("distance_miles")
+    base = finish or moving
+    if base and dist:
+        pace = base / dist
+        m["avg_pace_seconds"] = int(pace)
+        m["avg_pace_display"] = _format_pace(pace)
+
+    return m
+
+
+def get_historical_fade(conn, target_distance=None, tolerance_pct=15.0):
+    """Mean late-race fade % across the athlete's non-DNF same-distance races.
+
+    Used by the Race Day Engine to bias the late-race fatigue curve toward the
+    athlete's documented failure mode. Returns None when no fade data exists.
+    """
+    fades = []
+    for race in get_races(conn, target_distance, tolerance_pct, include_dnf=False):
+        f = race_metrics(race)["fade_pct"]
+        if f is not None and f > 0:
+            fades.append(f)
+    return round(statistics.mean(fades), 1) if fades else None
+
+
+# ---------------------------------------------------------------------------
+# Analysis — the object consumed by coaching / programming / race reports
+# ---------------------------------------------------------------------------
+
+def analyze_history(conn, target_distance=None, tolerance_pct=15.0):
+    """Aggregate the athlete's prior races into actionable lessons.
+
+    Returns a dict with per-race metrics, aggregate stats, the dominant failure
+    mode, coaching lessons, and training implications.
+    """
+    races = get_races(conn, target_distance, tolerance_pct, include_dnf=True)
+
+    enriched = []
+    for r in races:
+        metrics = race_metrics(r)
+        enriched.append({
+            "name": r["name"],
+            "race_date": r["race_date"],
+            "distance_miles": r["distance_miles"],
+            "elevation_gain_ft": r["elevation_gain_ft"],
+            "terrain": r["terrain"],
+            "dnf": bool(r["dnf"]),
+            "finish_time": _format_time(r["finish_time_seconds"]) if r["finish_time_seconds"] else None,
+            "first_half": _format_time(r["first_half_seconds"]) if r["first_half_seconds"] else None,
+            "second_half": _format_time(r["second_half_seconds"]) if r["second_half_seconds"] else None,
+            "avg_hr": r["avg_hr"],
+            "notes": r["notes"],
+            **metrics,
+        })
+
+    if not enriched:
+        return {
+            "count": 0,
+            "target_distance": target_distance,
+            "races": [],
+            "message": "No prior races on file. Seed with: ultra race history --seed",
+        }
+
+    faded = [e for e in enriched if e["fade_pct"] is not None]
+    fades = [e["fade_pct"] for e in faded]
+    avg_fade = round(statistics.mean(fades), 1) if fades else None
+    worst = max(faded, key=lambda e: e["fade_pct"]) if faded else None
+    best = min(faded, key=lambda e: e["fade_pct"]) if faded else None
+    dnfs = [e for e in enriched if e["dnf"]]
+    positive_splits = [e for e in enriched if e["positive_split"]]
+
+    lessons = []
+    implications = []
+    failure_mode = None
+
+    if fades:
+        if avg_fade > 8:
+            failure_mode = "late-race fade (positive split)"
+            lessons.append(
+                f"Late fade is the #1 failure mode: average second-half slowdown "
+                f"of {avg_fade}% across {len(fades)} efforts "
+                f"({len(positive_splits)}/{len(enriched)} were positive splits). "
+                f"The BR100 26h target lives or dies on the second half."
+            )
+            implications.append(
+                "Bias long runs toward negative-split execution; rehearse "
+                "back-half-fast finishes and B2B fatigue resistance."
+            )
+        if worst:
+            lessons.append(
+                f"Worst fade: {worst['name']} ({worst['fade_pct']}%)"
+                + (f" — {worst['notes']}" if worst.get("notes") else "")
+            )
+        if best and best["fade_pct"] <= 15:
+            lessons.append(
+                f"Best pacing template: {best['name']} ({best['fade_pct']}% fade)"
+                + (f" — {best['notes']}" if best.get("notes") else "")
+            )
+
+    # Aerobic-capability signal: a low avg HR alongside a big fade means the
+    # limiter was discipline/durability, not engine.
+    for e in enriched:
+        if e["avg_hr"] and e["avg_hr"] < 130 and e["fade_pct"] and e["fade_pct"] > 20:
+            lessons.append(
+                f"{e['name']}: avg HR {e['avg_hr']} with {e['fade_pct']}% fade — "
+                f"aerobically under-stressed, so the late collapse was durability/"
+                f"discipline, not fitness."
+            )
+
+    if dnfs:
+        lessons.append(
+            f"{len(dnfs)} DNF/short on file ("
+            + ", ".join(e["name"] for e in dnfs)
+            + ") — weather/mental low-patches ended races that fitness could finish. "
+            "Build explicit contingencies for night, heat, and dark patches."
+        )
+        implications.append(
+            "Treat mental/weather contingency planning as a first-class race-prep item."
+        )
+
+    # Elevation reality check vs BR100 (~10,568 ft).
+    finishers = [e for e in enriched if not e["dnf"] and e["elevation_gain_ft"]]
+    if finishers:
+        hilliest = max(finishers, key=lambda e: e["elevation_gain_ft"])
+        if hilliest["elevation_gain_ft"] < 10568:
+            implications.append(
+                f"BR100 (~10,568 ft) is hillier than every prior finish "
+                f"(max {int(hilliest['elevation_gain_ft'])} ft at {hilliest['name']}); "
+                f"26h needs better second-half discipline than any prior 100."
+            )
+
+    return {
+        "count": len(enriched),
+        "target_distance": target_distance,
+        "tolerance_pct": tolerance_pct,
+        "avg_fade_pct": avg_fade,
+        "historical_fade_pct": get_historical_fade(conn, target_distance, tolerance_pct),
+        "positive_split_count": len(positive_splits),
+        "dnf_count": len(dnfs),
+        "failure_mode": failure_mode,
+        "lessons": lessons,
+        "training_implications": implications,
+        "races": enriched,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Strava enrichment (optional — requires a connected token)
+# ---------------------------------------------------------------------------
+
+def enrich_from_strava(conn, race_id, activity_id):
+    """Pull detail for one activity and fill in missing fields on a race row.
+
+    Fills distance, elevation, finish (elapsed) + moving time, and avg HR. Half
+    splits are computed from ``splits_standard`` (mile splits) when present.
+    Raises RuntimeError if Strava isn't connected.
+    """
+    from . import strava  # lazy: avoids requiring `requests` for offline use
+
+    act = strava.get_activity_detail(activity_id)
+
+    dist_mi = round(act["distance"] / 1609.34, 2) if act.get("distance") else None
+    elev_ft = round(act["total_elevation_gain"] * 3.28084, 0) if act.get("total_elevation_gain") else None
+    elapsed = act.get("elapsed_time")
+    moving = act.get("moving_time")
+    avg_hr = round(act["average_heartrate"]) if act.get("average_heartrate") else None
+
+    first_half = second_half = first_hr = second_hr = None
+    splits = act.get("splits_standard") or []
+    if splits:
+        n = len(splits)
+        half = n // 2
+        first = splits[:half]
+        second = splits[half:]
+        if first and second:
+            first_half = sum(s.get("moving_time", s.get("elapsed_time", 0)) for s in first)
+            second_half = sum(s.get("moving_time", s.get("elapsed_time", 0)) for s in second)
+            fh_hrs = [s["average_heartrate"] for s in first if s.get("average_heartrate")]
+            sh_hrs = [s["average_heartrate"] for s in second if s.get("average_heartrate")]
+            if fh_hrs:
+                first_hr = round(statistics.mean(fh_hrs))
+            if sh_hrs:
+                second_hr = round(statistics.mean(sh_hrs))
+
+    # Only overwrite fields we actually pulled (COALESCE-style: keep existing).
+    updates = {
+        "distance_miles": dist_mi,
+        "elevation_gain_ft": elev_ft,
+        "finish_time_seconds": elapsed,
+        "moving_time_seconds": moving,
+        "avg_hr": avg_hr,
+        "first_half_seconds": first_half,
+        "second_half_seconds": second_half,
+        "first_half_hr": first_hr,
+        "second_half_hr": second_hr,
+        "strava_activity_id": activity_id,
+    }
+    updates = {k: v for k, v in updates.items() if v is not None}
+    if updates:
+        assignments = ", ".join(f"{k} = ?" for k in updates)
+        conn.execute(
+            f"UPDATE athlete_races SET {assignments} WHERE id = ?",
+            (*updates.values(), race_id),
+        )
+    return updates
+
+
+# ---------------------------------------------------------------------------
+# Markdown rendering (race-report / vault output)
+# ---------------------------------------------------------------------------
+
+def history_to_markdown(analysis):
+    """Render an analysis dict as a markdown report."""
+    if not analysis.get("count"):
+        return "# Historical Race Analysis\n\nNo prior races on file.\n"
+
+    lines = ["# Historical Race Analysis — Prior Efforts", ""]
+    if analysis.get("target_distance"):
+        lines.append(
+            f"_Races within ±{analysis['tolerance_pct']:.0f}% of "
+            f"{analysis['target_distance']} mi._\n"
+        )
+    if analysis.get("failure_mode"):
+        lines.append(f"**Dominant failure mode:** {analysis['failure_mode']}  ")
+    if analysis.get("avg_fade_pct") is not None:
+        lines.append(f"**Average late-race fade:** {analysis['avg_fade_pct']}%  ")
+    lines.append("")
+
+    lines.append("| Race | Date | Dist | Finish | Fade | Avg Pace | Stoppage |")
+    lines.append("|---|---|---|---|---|---|---|")
+    for r in analysis["races"]:
+        fade = f"+{r['fade_pct']}%" if r.get("fade_pct") is not None else "—"
+        finish = r.get("finish_time") or ("DNF" if r["dnf"] else "—")
+        pace = r.get("avg_pace_display") or "—"
+        stop = (f"{r['stoppage_pct']}%" if r.get("stoppage_pct") is not None else "—")
+        lines.append(
+            f"| {r['name']} | {r['race_date']} | {r['distance_miles']} | "
+            f"{finish} | {fade} | {pace} | {stop} |"
+        )
+    lines.append("")
+
+    if analysis.get("lessons"):
+        lines.append("## Lessons")
+        for l in analysis["lessons"]:
+            lines.append(f"- {l}")
+        lines.append("")
+
+    if analysis.get("training_implications"):
+        lines.append("## Training Implications")
+        for i in analysis["training_implications"]:
+            lines.append(f"- {i}")
+        lines.append("")
+
+    return "\n".join(lines)

--- a/backend/llm.py
+++ b/backend/llm.py
@@ -359,7 +359,8 @@ def analyze_run_feedback(prescribed: dict, actual: dict,
                          benchmarks: list[dict] | None = None,
                          race_info: dict | None = None,
                          athlete_targets: dict | None = None,
-                         nutrition_data: dict | None = None) -> dict:
+                         nutrition_data: dict | None = None,
+                         historical_data: dict | None = None) -> dict:
     """Analyze a completed run against the prescribed workout and return structured feedback."""
 
     system_prompt = """You are an experienced ultramarathon coach analyzing a training run for an athlete preparing for a 100-mile race (Burning River 100, July 25, 2026, sub-24hr goal).
@@ -373,6 +374,10 @@ COACHING PRINCIPLES:
 - During taper: feeling flat/sluggish is NORMAL and expected. Don't panic.
 - MAF test improvement (more distance at same HR) = aerobic fitness improving
 - Pace decay in long runs should decrease over training cycle
+- If the athlete's prior-race history is provided, coach against their documented
+  failure mode (e.g. late-race fade / positive split). Reinforce pacing discipline
+  and negative-split execution when a run echoes that pattern, and call out progress
+  when a run shows the opposite (e.g. HR or pace holding/falling in the back half).
 
 NUTRITION COACHING:
 - <60 min runs: water only, no fuel needed
@@ -414,6 +419,11 @@ Respond with JSON only:
         user_msg_parts.append(f"\n## Current Athlete Targets\n{json.dumps(athlete_targets, indent=2, default=str)}")
     if nutrition_data:
         user_msg_parts.append(f"\n## Nutrition Report\n{json.dumps(nutrition_data, indent=2, default=str)}")
+    if historical_data:
+        user_msg_parts.append(
+            "\n## Historical Race Analysis (athlete's own prior efforts)\n"
+            + json.dumps(historical_data, indent=2, default=str)
+        )
 
     user_msg_parts.append("\nAnalyze this run and provide structured feedback.")
 

--- a/backend/race_engine.py
+++ b/backend/race_engine.py
@@ -407,11 +407,13 @@ def grade_adjusted_pace(base_pace_seconds, grade_pct):
     return base_pace_seconds + adjustment
 
 
-def fatigue_multiplier(mile, total_miles, training_fade=None, cohort_slowdown_pct=None):
+def fatigue_multiplier(mile, total_miles, training_fade=None, cohort_slowdown_pct=None,
+                       historical_fade_pct=None):
     """Calculate fatigue-based pace multiplier at a given point in the race.
 
-    Blends training data (B2B fade) with peer cohort slowdown curve.
-    Returns multiplier > 1.0 (e.g., 1.15 = 15% slower than fresh pace).
+    Blends training data (B2B fade), peer cohort slowdown curve, and the
+    athlete's own prior-race late fade. Returns multiplier > 1.0 (e.g., 1.15 =
+    15% slower than fresh pace).
     """
     progress = mile / total_miles if total_miles > 0 else 0
 
@@ -436,6 +438,13 @@ def fatigue_multiplier(mile, total_miles, training_fade=None, cohort_slowdown_pc
         # Apply training fade influence in middle miles
         if 0.3 < progress < 0.8:
             base_fatigue *= (1.0 + fade_factor * 0.3)
+
+    # Bias the late race toward the athlete's documented prior-race fade.
+    # Bounded and back-loaded so a ~20% historical positive split adds only a
+    # few percent at the very end, where the athlete has historically collapsed.
+    if historical_fade_pct is not None and historical_fade_pct > 0 and progress > 0.5:
+        hist_factor = historical_fade_pct / 100
+        base_fatigue *= (1.0 + hist_factor * 0.15 * progress)
 
     return round(base_fatigue, 4)
 
@@ -512,6 +521,13 @@ def generate_race_plan(conn, course_id, plan_id, goal_time_seconds,
     # Get training fade
     training_fade = get_training_fade(conn, plan_id) if plan_id else None
 
+    # Get the athlete's own prior-race late fade (same-distance efforts).
+    from . import historical  # lazy: historical imports race_engine helpers
+    try:
+        historical_fade = historical.get_historical_fade(conn, target_distance=total_miles)
+    except Exception:
+        historical_fade = None
+
     # Generate three scenarios
     scenarios = {
         "A": {"label": "Goal Pace", "multiplier": 1.0},
@@ -535,7 +551,8 @@ def generate_race_plan(conn, course_id, plan_id, goal_time_seconds,
 
             # Apply fatigue curve
             fatigue = fatigue_multiplier(
-                mid_mile, total_miles, training_fade, cohort_slowdown
+                mid_mile, total_miles, training_fade, cohort_slowdown,
+                historical_fade,
             )
             seg_pace *= fatigue
 
@@ -600,6 +617,7 @@ def generate_race_plan(conn, course_id, plan_id, goal_time_seconds,
         "start_time": start_time,
         "base_pace_display": _format_pace(base_pace_sec),
         "training_fade_pct": training_fade,
+        "historical_fade_pct": historical_fade,
         "cohort_slowdown_pct": cohort_slowdown,
         "cohort_size": cohort_data.get("cohort_size", 0),
         "plans": plans,

--- a/backend/tests/test_historical.py
+++ b/backend/tests/test_historical.py
@@ -1,0 +1,108 @@
+"""Tests for backend.historical — the athlete's own prior-race analysis.
+
+Run with: ``python3 -m unittest backend.tests.test_historical -v`` from repo root.
+
+Each test runs against a throwaway SQLite file so the real ``workouts.db`` is
+never touched. ``database.DB_PATH`` is patched before ``init_db`` runs.
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from backend import database
+
+
+class HistoricalTestCase(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+        self._tmp.close()
+        self._patcher = patch.object(database, "DB_PATH", self._tmp.name)
+        self._patcher.start()
+        database.init_db()
+        # Import after patching so the module's get_db uses the temp path.
+        from backend import historical
+        self.historical = historical
+
+    def tearDown(self):
+        self._patcher.stop()
+        os.unlink(self._tmp.name)
+
+
+class SeedAndMetricsTests(HistoricalTestCase):
+    def test_seed_is_idempotent(self):
+        with database.get_db() as conn:
+            self.historical.seed_known_races(conn)
+            self.historical.seed_known_races(conn)  # second seed must not dup
+            rows = conn.execute("SELECT COUNT(*) FROM athlete_races").fetchone()[0]
+        self.assertEqual(rows, len(self.historical.KNOWN_RACES))
+
+    def test_fade_and_stoppage_metrics(self):
+        # Tunnel Hill: 13:03 -> 14:56 halves, 25:23 elapsed / 23:34 moving.
+        race = {
+            "first_half_seconds": 13 * 3600 + 3 * 60,
+            "second_half_seconds": 14 * 3600 + 56 * 60,
+            "finish_time_seconds": 25 * 3600 + 23 * 60,
+            "moving_time_seconds": 23 * 3600 + 34 * 60,
+            "distance_miles": 101.1,
+            "first_half_hr": None,
+            "second_half_hr": None,
+        }
+        m = self.historical.race_metrics(race)
+        self.assertAlmostEqual(m["fade_pct"], 14.4, places=1)
+        self.assertTrue(m["positive_split"])
+        self.assertEqual(m["stoppage_seconds"], 6540)
+        self.assertAlmostEqual(m["stoppage_pct"], 7.2, places=1)
+
+    def test_hr_drift(self):
+        m = self.historical.race_metrics(
+            {"first_half_hr": 140, "second_half_hr": 132}
+        )
+        self.assertEqual(m["hr_drift_bpm"], -8)
+
+
+class AnalysisTests(HistoricalTestCase):
+    def test_failure_mode_and_implications(self):
+        with database.get_db() as conn:
+            self.historical.seed_known_races(conn)
+            analysis = self.historical.analyze_history(conn)
+        self.assertEqual(analysis["count"], len(self.historical.KNOWN_RACES))
+        self.assertEqual(analysis["failure_mode"], "late-race fade (positive split)")
+        self.assertGreater(analysis["avg_fade_pct"], 8)
+        self.assertTrue(analysis["lessons"])
+        # BR100 elevation reality-check implication should fire.
+        self.assertTrue(any("hillier" in i for i in analysis["training_implications"]))
+
+    def test_distance_filter_excludes_off_distance(self):
+        with database.get_db() as conn:
+            self.historical.seed_known_races(conn)
+            self.historical.add_race(
+                conn, name="Local 50K", race_date="2024-09-01",
+                distance_miles=31.0, finish_time_seconds=18000,
+            )
+            full = self.historical.analyze_history(conn)
+            near100 = self.historical.analyze_history(conn, target_distance=100)
+        names = {r["name"] for r in near100["races"]}
+        self.assertIn("Local 50K", {r["name"] for r in full["races"]})
+        self.assertNotIn("Local 50K", names)
+        self.assertNotIn("Canal Corridor 100", names)  # 76.8 mi, outside ±15%
+
+    def test_historical_fade_positive(self):
+        with database.get_db() as conn:
+            self.historical.seed_known_races(conn)
+            fade = self.historical.get_historical_fade(conn, target_distance=100)
+        self.assertIsNotNone(fade)
+        self.assertGreater(fade, 0)
+
+    def test_empty_history_message(self):
+        with database.get_db() as conn:
+            analysis = self.historical.analyze_history(conn)
+        self.assertEqual(analysis["count"], 0)
+        self.assertIn("Seed", analysis["message"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds `ultra race history` to ingest and analyze the athlete's own prior
races at a given distance and feed the lessons into coaching, programming,
and race reports (issue #13).

- New `athlete_races` table (distinct from course-bound `historical_results`,
  which holds peer finishers). Stores finish/moving time, half splits, avg HR,
  elevation, terrain, DNF, and Strava id per effort.
- `backend/historical.py`: seed known prior 100s, manual `--add`, optional
  Strava enrichment, and `analyze_history()` computing late fade, positive
  split, HR drift, and stoppage; surfaces the dominant failure mode, coaching
  lessons, and training implications. Markdown + JSON output.
- Coaching: prior-race summary threaded into `analyze_run_feedback` so run
  reports coach against the documented late-fade failure mode.
- Race reports: `get_historical_fade()` biases the Race Day Engine's late-race
  fatigue curve (bounded, back-loaded) toward the athlete's own prior fade.
- Tests for seeding idempotency, metrics, distance filtering, and analysis.
- Docs: CLAUDE.md and README updated.

https://claude.ai/code/session_01MzUAirC6guK9uDXrsJxZsv