### PR TITLE
Add `race load-aid-stations` to populate course segments from an aid-station chart (#18)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,7 +111,16 @@ python3 cli.py ultra race load-course <gpx_file> --name "Burning River 100" --ye
 python3 cli.py ultra race load-course course.gpx --name "BR100" --year 2026 \
   --segment-breaks "5.2,12.8,20.1,31.4,40.2,50.0,62.5,75.3,87.9" --json
 
-# View/edit course segments (set aid station names, crew access, drop bags)
+# Populate ALL segments at once from an aid-station chart (names + crew/drop-bag).
+# Re-derives segments at the real aid-station miles (recomputing elevation from
+# the loaded course's GPX) and replaces them in place — no duplicate course row.
+# BR100's chart is committed at backend/data/br100_aid_stations_2026.csv.
+python3 cli.py ultra race load-aid-stations backend/data/br100_aid_stations_2026.csv --dry-run
+python3 cli.py ultra race load-aid-stations backend/data/br100_aid_stations_2026.csv --json
+# CSV columns: mile,name,crew,drop_bag,notes (lines starting with # are ignored).
+# Re-pull the participant guide and re-run if mile markers shift year to year.
+
+# View/edit individual course segments (one-off tweaks after a bulk load)
 python3 cli.py ultra race segments --json
 python3 cli.py ultra race segments --segment 3 --set-name "Happy Days 1" --crew 1 --drop-bag 1
 

--- a/README.md
+++ b/README.md
@@ -124,9 +124,9 @@ PROGRESS         ▶  progress  benchmarks
 DEVICE SYNC      ▶  strava-{connect, status, import}
                     icu-push  export-fit
 
-RACE DAY         ▶  race {load-course, cohort, plan, nutrition,
-                          crew-sheet, checkin, status, segments,
-                          import-results, history}
+RACE DAY         ▶  race {load-course, load-aid-stations, cohort,
+                          plan, nutrition, crew-sheet, checkin, status,
+                          segments, import-results, history}
 
 EXPORT           ▶  plan --export-md
 
@@ -194,11 +194,12 @@ Every command in `backend/cli.py` appears in exactly one block below. Examples u
 </details>
 
 <details>
-<summary><b>Race day</b> · load-course  import-results  history  cohort  plan  nutrition  crew-sheet  checkin  status  segments</summary>
+<summary><b>Race day</b> · load-course  load-aid-stations  import-results  history  cohort  plan  nutrition  crew-sheet  checkin  status  segments</summary>
 
 | Command | What it does | Example |
 |---|---|---|
 | `ultra ultra race load-course` | Load a race course from a GPX file. Optionally pass `--segment-breaks` to define aid-station mile markers. | `ultra ultra race load-course course.gpx --name "BR100" --year 2026` |
+| `ultra ultra race load-aid-stations` | Populate every segment at once from an aid-station CSV (`mile,name,crew,drop_bag,notes`): re-derives segments at the real aid miles, names them, sets crew/drop-bag flags, replacing them in place. `--dry-run` previews. | `ultra ultra race load-aid-stations backend/data/br100_aid_stations_2026.csv` |
 | `ultra ultra race import-results` | Import historical finisher splits from CSV for peer-cohort analysis. | `ultra ultra race import-results results.csv --year 2025` |
 | `ultra ultra race history` | Ingest & analyze the athlete's *own* prior races at the same distance (late fade, positive split, HR drift, stoppage). Feeds coaching, training implications, and the Race Day Engine's late-race fade. `--seed`, `--add`, `--json`, `--md`. | `ultra ultra race history --seed && ultra ultra race history --distance-filter 100` |
 | `ultra ultra race cohort` | Build a peer cohort of historical finishers near a goal time. | `ultra ultra race cohort --goal-time 24:00:00 --json` |

--- a/backend/cli.py
+++ b/backend/cli.py
@@ -1424,6 +1424,56 @@ def cmd_race_load_course(args):
                   f"avg {s['avg_grade_pct']:.1f}%")
 
 
+def cmd_race_load_aid_stations(args):
+    with get_db() as conn:
+        try:
+            stations = race_engine.read_aid_stations_csv(args.csv_file)
+        except FileNotFoundError:
+            _err(f"Aid-station file not found: {args.csv_file}", args.json, 2)
+        if not stations:
+            _err(f"No aid stations parsed from {args.csv_file}", args.json, 2)
+
+        try:
+            result = race_engine.import_aid_stations(
+                conn, stations, course_id=args.course_id, dry_run=args.dry_run,
+            )
+        except (ValueError, FileNotFoundError) as e:
+            _err(str(e), args.json, 2)
+
+    segments = result["segments"]
+    if args.json:
+        _print(result, True)
+        return
+
+    verb = "Would rebuild" if args.dry_run else "Rebuilt"
+    print(f"{verb} {result['course']} from {len(stations)} aid stations")
+    print(f"Distance: {result['total_distance_miles']} mi | "
+          f"Gain: {result['total_elevation_gain_ft']} ft | "
+          f"Segments: {result['segment_count']}")
+    for s in segments:
+        flags = []
+        if s["crew_accessible"]:
+            flags.append("crew")
+        if s["drop_bag"]:
+            flags.append("drop")
+        tag = f" [{'+'.join(flags)}]" if flags else ""
+        print(f"  {s['segment_number']:2d}. {s['name']:<22} "
+              f"mile {s['end_mile']:5.1f} "
+              f"(+{s['elevation_gain_ft']:.0f}/-{s['elevation_loss_ft']:.0f}ft){tag}")
+
+    dep = result["dependents"]
+    lost = sum(dep.values())
+    if lost and not args.dry_run:
+        print(f"\nNote: removed {lost} saved row(s) tied to the old segments "
+              f"({dep}). Regenerate race plans with `ultra race plan --save`.")
+    elif lost and args.dry_run:
+        print(f"\nWarning: applying this would cascade-delete {lost} saved row(s) "
+              f"({dep}). Regenerate race plans afterward.")
+
+    if args.dry_run:
+        print("\nDry run — no changes written. Re-run without --dry-run to apply.")
+
+
 def cmd_race_import_results(args):
     with get_db() as conn:
         course = race_engine.get_course(conn, name=args.course_name)
@@ -1992,6 +2042,18 @@ def main():
                        help="Comma-separated mile markers for segments (e.g. '5.2,12.8,20.1')")
     rlc_p.add_argument("--json", action="store_true")
 
+    # ultra race load-aid-stations
+    rla_p = race_sub.add_parser(
+        "load-aid-stations",
+        help="Populate course segments from an aid-station CSV (names + crew/drop-bag)")
+    rla_p.add_argument("csv_file", type=str,
+                       help="Aid-station CSV (columns: mile,name,crew,drop_bag,notes)")
+    rla_p.add_argument("--course-id", type=int,
+                       help="Course id to rebuild (default: latest loaded course)")
+    rla_p.add_argument("--dry-run", action="store_true",
+                       help="Preview the rebuilt segments without writing")
+    rla_p.add_argument("--json", action="store_true")
+
     # ultra race import-results
     rir_p = race_sub.add_parser("import-results", help="Import historical race results from CSV")
     rir_p.add_argument("csv_file", type=str, help="Path to CSV file")
@@ -2148,6 +2210,7 @@ def main():
 
             race_commands = {
                 "load-course": cmd_race_load_course,
+                "load-aid-stations": cmd_race_load_aid_stations,
                 "import-results": cmd_race_import_results,
                 "history": cmd_race_history,
                 "cohort": cmd_race_cohort,

--- a/backend/data/br100_aid_stations_2026.csv
+++ b/backend/data/br100_aid_stations_2026.csv
@@ -1,0 +1,32 @@
+# Burning River 100 — aid station chart, 2026 Participant Guide (Aid Station Overview, REV 1/16/26).
+# Out-and-back, 4:00 AM start, 30-hour cutoff. Total ~101.8 mi (matches V2 GPX 101.77 mi).
+# Columns: mile = cumulative race mile of the aid station (= segment END mile);
+#          crew/drop_bag = 1 if allowed for the 100-miler (CREW column non-blank / DROP BAGS = X);
+#          notes = cutoff (CLOSE) time, aid type, and food offering for the crew manual (#12).
+# Each physical station appears twice (outbound + return) except the turnaround and finish.
+# Source of truth for `ultra race load-aid-stations`. Re-pull the guide and re-run if miles shift.
+mile,name,crew,drop_bag,notes
+4.7,Schumacher,0,0,close 8:14 AM; water/ice only
+8.9,North Hawkins,1,0,close 9:21 AM; full aid; PB&J/bacon
+12.4,Chestnut Shelter,0,1,close 10:16 AM; full aid; PB&J/bacon
+14.0,Botzum,1,0,close 10:42 AM; Skratch + water/ice
+19.5,Indigo Lake,0,0,close 12:10 PM; self-serve gallon jugs
+22.9,Oak Hill,1,1,close 1:04 PM; full aid; grilled cheese/potatoes
+26.7,Valley Picnic,0,0,close 2:04 PM; full aid; deli sandwiches
+30.3,Robinson Field,0,0,close 3:01 PM; Skratch + water/ice
+34.5,Pine Hollow,1,0,close 4:08 PM; full aid; pierogies/PB&J
+40.4,Kendall Lake,0,1,close 5:43 PM; full aid; veg fried rice (wheat/soy)
+45.7,Rt. 8 (Bike & Hike),0,0,close 7:08 PM; full aid; deli sandwiches
+50.7,Silver Springs,1,1,50M turnaround; pacers allowed from here; close 8:30 PM; ground beef/mashed potatoes
+55.9,Rt. 8 (Bike & Hike),0,0,close 9:49 PM; full aid; deli sandwiches
+61.2,Kendall Lake,0,1,close 11:14 PM; full aid; veg fried rice (wheat/soy)
+67.2,Pine Hollow,1,0,close 12:49 AM; full aid; pierogies/PB&J/broth/ramen
+71.4,Robinson Field,0,0,close 1:56 AM; full aid; deli sandwiches/broth/ramen
+75.0,Valley Picnic,0,0,close 2:54 AM; full aid; pierogies/PB&J/broth/ramen
+78.2,Oak Hill,1,1,close 3:54 AM; full aid; pierogies/mashed potatoes/soup/broth
+82.2,Indigo Lake,0,0,close 4:48 AM; self-serve gallon jugs
+87.7,Botzum,1,0,close 6:15 AM; Skratch + water/ice
+89.4,Chestnut Shelter,0,1,close 6:43 AM; full aid; veg fried rice (wheat/soy)
+92.9,North Hawkins,1,0,close 7:38 AM; full aid; deli sandwiches/broth/ramen
+97.1,Schumacher,1,0,close 8:44 AM; full aid; pierogies/PB&J/bacon/broth/ramen
+101.8,Finish,1,1,close 10:00 AM (30-hr cutoff); pancakes/syrup/veg soup

--- a/backend/race_engine.py
+++ b/backend/race_engine.py
@@ -223,6 +223,172 @@ def get_segments(conn, course_id):
 
 
 # ---------------------------------------------------------------------------
+# 1b. Aid-Station Import (segment breaks + names + crew/drop-bag flags)
+# ---------------------------------------------------------------------------
+
+def _truthy(value):
+    """Interpret a CSV cell as a boolean flag.
+
+    Accepts 1/0, yes/no, true/false, x, and crew-style codes like ``50/100``
+    or ``100`` (any non-empty, non-falsey value counts as set).
+    """
+    if value is None:
+        return False
+    s = str(value).strip().lower()
+    if s in ("", "0", "no", "false", "n", "-"):
+        return False
+    return True
+
+
+def read_aid_stations_csv(csv_file_path):
+    """Read an aid-station file into normalized station dicts.
+
+    Expected columns: ``mile``, ``name`` (required); ``crew``, ``drop_bag``,
+    ``notes`` (optional). Lines beginning with ``#`` and blank lines are skipped
+    so the file can carry provenance/comments. Returns a list sorted by mile.
+    """
+    stations = []
+    with open(csv_file_path, "r") as f:
+        rows = [ln for ln in f if ln.strip() and not ln.lstrip().startswith("#")]
+        reader = csv.DictReader(rows)
+        for row in reader:
+            mile_raw = (row.get("mile") or "").strip()
+            name = (row.get("name") or "").strip()
+            if not mile_raw or not name:
+                continue
+            stations.append({
+                "mile": round(float(mile_raw), 2),
+                "name": name,
+                "crew": _truthy(row.get("crew")),
+                "drop_bag": _truthy(row.get("drop_bag")),
+                "notes": (row.get("notes") or "").strip() or None,
+            })
+    return sorted(stations, key=lambda s: s["mile"])
+
+
+def build_aid_station_segments(points, stations):
+    """Re-derive segments from GPX trackpoints using aid stations as breaks.
+
+    Each station's mile becomes a segment-end break; the resulting segment is
+    named after the station at its end and inherits its crew/drop-bag flags and
+    notes. Returns ``(segments, total_distance_miles, total_gain_ft)``.
+    """
+    stations = sorted(stations, key=lambda s: s["mile"])
+    breaks = [s["mile"] for s in stations]
+
+    # The guide's aid miles and the GPX distance rarely match exactly (issue #18
+    # flags ~100.7 guide mi vs ~101.8 GPX mi). The last station is the finish, so
+    # snap its break to the true course end — otherwise build_segments_from_gpx
+    # appends an unnamed tail segment that would mislabel as a duplicate finish.
+    if points and breaks:
+        total_miles = points[-1]["cumulative_distance_m"] * METERS_TO_MILES
+        breaks[-1] = max(breaks[-1], round(total_miles, 2))
+
+    segments, total_dist, total_gain = build_segments_from_gpx(points, breaks)
+
+    for seg in segments:
+        # Match each rebuilt segment to the station nearest its end mile. Index
+        # matching is fragile if a sparse segment gets skipped, so match by mile.
+        station = min(stations, key=lambda s: abs(s["mile"] - seg["end_mile"]))
+        seg["name"] = station["name"]
+        seg["crew_accessible"] = 1 if station["crew"] else 0
+        seg["drop_bag"] = 1 if station["drop_bag"] else 0
+        seg["terrain_notes"] = station["notes"]
+
+    return segments, total_dist, total_gain
+
+
+def _course_dependents(conn, course_id):
+    """Count saved rows that reference this course's segments and would be lost
+    on a rebuild (FK ON DELETE CASCADE clears them when segments are replaced)."""
+    return {
+        "historical_splits": conn.execute(
+            """SELECT COUNT(*) FROM historical_splits
+               WHERE segment_id IN (SELECT id FROM race_segments WHERE course_id = ?)""",
+            (course_id,),
+        ).fetchone()[0],
+        "race_plan_segments": conn.execute(
+            """SELECT COUNT(*) FROM race_plan_segments
+               WHERE segment_id IN (SELECT id FROM race_segments WHERE course_id = ?)""",
+            (course_id,),
+        ).fetchone()[0],
+        "race_checkins": conn.execute(
+            """SELECT COUNT(*) FROM race_checkins
+               WHERE segment_id IN (SELECT id FROM race_segments WHERE course_id = ?)""",
+            (course_id,),
+        ).fetchone()[0],
+    }
+
+
+def import_aid_stations(conn, stations, course_id=None, dry_run=False):
+    """Rebuild a loaded course's segments from an aid-station list.
+
+    Re-parses the course's stored GPX, breaks it at the aid-station miles, names
+    each segment after the station at its end, and sets crew/drop-bag flags —
+    replacing the course's segments in place (no duplicate course row). Pass
+    ``dry_run=True`` to preview without writing.
+
+    Returns a result dict with the rebuilt segments, totals, and a ``dependents``
+    count of saved splits/plans/check-ins that a write would cascade-delete.
+    """
+    course = get_course(conn, course_id=course_id)
+    if not course:
+        raise ValueError("No course loaded. Run `ultra race load-course` first.")
+
+    gpx_path = course.get("gpx_file_path")
+    if not gpx_path or not Path(gpx_path).exists():
+        raise FileNotFoundError(
+            f"Course GPX not found at {gpx_path!r}. The aid-station import "
+            "recomputes per-segment elevation from the original GPX, so the "
+            "file referenced by the loaded course must be present."
+        )
+
+    points = parse_gpx(gpx_path)
+    segments, total_dist, total_gain = build_aid_station_segments(points, stations)
+    dependents = _course_dependents(conn, course["id"])
+
+    result = {
+        "course_id": course["id"],
+        "course": course["name"],
+        "total_distance_miles": total_dist,
+        "total_elevation_gain_ft": total_gain,
+        "segment_count": len(segments),
+        "crew_stations": [s["name"] for s in segments if s["crew_accessible"]],
+        "drop_bag_stations": [s["name"] for s in segments if s["drop_bag"]],
+        "dependents": dependents,
+        "segments": segments,
+        "applied": False,
+    }
+
+    if dry_run:
+        return result
+
+    conn.execute("DELETE FROM race_segments WHERE course_id = ?", (course["id"],))
+    for seg in segments:
+        conn.execute(
+            """INSERT INTO race_segments
+               (course_id, segment_number, name, start_mile, end_mile, distance_miles,
+                elevation_gain_ft, elevation_loss_ft, avg_grade_pct, max_grade_pct,
+                terrain_notes, crew_accessible, drop_bag)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            (course["id"], seg["segment_number"], seg["name"], seg["start_mile"],
+             seg["end_mile"], seg["distance_miles"], seg["elevation_gain_ft"],
+             seg["elevation_loss_ft"], seg["avg_grade_pct"], seg["max_grade_pct"],
+             seg["terrain_notes"], seg["crew_accessible"], seg["drop_bag"]),
+        )
+
+    # Keep the course totals consistent with the new segmentation.
+    conn.execute(
+        """UPDATE race_courses SET total_distance_miles = ?,
+           total_elevation_gain_ft = ? WHERE id = ?""",
+        (total_dist, total_gain, course["id"]),
+    )
+
+    result["applied"] = True
+    return result
+
+
+# ---------------------------------------------------------------------------
 # 2. Historical Finisher Analysis
 # ---------------------------------------------------------------------------
 

--- a/backend/tests/test_aid_stations.py
+++ b/backend/tests/test_aid_stations.py
@@ -1,0 +1,179 @@
+"""Tests for aid-station import — populating named, flagged course segments.
+
+Run with: ``python3 -m unittest backend.tests.test_aid_stations -v`` from repo root.
+
+Uses a throwaway SQLite file and a synthetic GPX (the real BR100 GPX is not in
+the repo), so the real ``workouts.db`` and course data are never touched.
+"""
+
+from __future__ import annotations
+
+import math
+import os
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from backend import database
+
+
+def _write_synthetic_gpx(path, n=200, lat0=40.0, lon0=-81.5):
+    """Write a GPX track that climbs then descends.
+
+    Steps of 0.0009 deg latitude are ~100 m apart, so ``n`` steps make a course
+    of roughly ``n * 100 m``. Returns nothing; just writes the file.
+    """
+    pts = []
+    for i in range(n + 1):
+        lat = lat0 + i * 0.0009
+        ele = 300 + 200 * math.sin(math.pi * i / n)  # hill: up then back down
+        pts.append(f'<trkpt lat="{lat:.6f}" lon="{lon0:.6f}"><ele>{ele:.1f}</ele></trkpt>')
+    gpx = (
+        '<?xml version="1.0" encoding="UTF-8"?>\n'
+        '<gpx version="1.1" creator="test"><trk><trkseg>\n'
+        + "\n".join(pts)
+        + "\n</trkseg></trk></gpx>\n"
+    )
+    with open(path, "w") as f:
+        f.write(gpx)
+
+
+class AidStationTestCase(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+        self._tmp.close()
+        self._patcher = patch.object(database, "DB_PATH", self._tmp.name)
+        self._patcher.start()
+        database.init_db()
+
+        self._gpx = tempfile.NamedTemporaryFile(suffix=".gpx", delete=False)
+        self._gpx.close()
+        _write_synthetic_gpx(self._gpx.name)
+
+        from backend import race_engine
+        self.race_engine = race_engine
+
+        # Load the synthetic course so an aid-station rebuild has something to act on.
+        with database.get_db() as conn:
+            cid, segs, total, gain = race_engine.load_course(
+                conn, self._gpx.name, "Test Course", 2026,
+            )
+        self.course_id = cid
+        self.total = total
+
+        # Aid stations at quarter points + finish; mix of crew/drop flags.
+        self.stations = [
+            {"mile": round(total * 0.25, 2), "name": "Quarter", "crew": True, "drop_bag": False, "notes": "close noon"},
+            {"mile": round(total * 0.50, 2), "name": "Half (turn)", "crew": True, "drop_bag": True, "notes": None},
+            {"mile": round(total * 0.75, 2), "name": "Three-Quarter", "crew": False, "drop_bag": True, "notes": None},
+            {"mile": round(total, 2), "name": "Finish", "crew": True, "drop_bag": True, "notes": None},
+        ]
+
+    def tearDown(self):
+        self._patcher.stop()
+        os.unlink(self._tmp.name)
+        os.unlink(self._gpx.name)
+
+
+class CsvParsingTests(AidStationTestCase):
+    def test_reads_and_sorts_skipping_comments(self):
+        csv = tempfile.NamedTemporaryFile(suffix=".csv", delete=False, mode="w")
+        csv.write(
+            "# a comment line\n"
+            "mile,name,crew,drop_bag,notes\n"
+            "8.9,North Hawkins,1,0,close 9:21 AM\n"
+            "4.7,Schumacher,0,0,water only\n"
+            "# trailing comment\n"
+        )
+        csv.close()
+        try:
+            stations = self.race_engine.read_aid_stations_csv(csv.name)
+        finally:
+            os.unlink(csv.name)
+        self.assertEqual([s["name"] for s in stations], ["Schumacher", "North Hawkins"])
+        self.assertEqual(stations[0]["mile"], 4.7)
+        self.assertFalse(stations[0]["crew"])
+        self.assertTrue(stations[1]["crew"])
+
+    def test_crew_code_values_are_truthy(self):
+        # The real guide uses CREW codes like "50/100" / "100", not 1/0.
+        self.assertTrue(self.race_engine._truthy("50/100"))
+        self.assertTrue(self.race_engine._truthy("100"))
+        self.assertTrue(self.race_engine._truthy("x"))
+        self.assertFalse(self.race_engine._truthy(""))
+        self.assertFalse(self.race_engine._truthy("-"))
+        self.assertFalse(self.race_engine._truthy("0"))
+
+
+class ImportTests(AidStationTestCase):
+    def test_rebuild_names_and_flags_segments(self):
+        with database.get_db() as conn:
+            result = self.race_engine.import_aid_stations(conn, self.stations, course_id=self.course_id)
+            segs = self.race_engine.get_segments(conn, self.course_id)
+
+        self.assertTrue(result["applied"])
+        self.assertEqual(len(segs), 4)
+        self.assertEqual([s["name"] for s in segs],
+                         ["Quarter", "Half (turn)", "Three-Quarter", "Finish"])
+        # Crew + drop flags land on the right segments.
+        self.assertEqual([s["crew_accessible"] for s in segs], [1, 1, 0, 1])
+        self.assertEqual([s["drop_bag"] for s in segs], [0, 1, 1, 1])
+        # Notes carried into terrain_notes.
+        self.assertEqual(segs[0]["terrain_notes"], "close noon")
+        # Final segment reaches the course end; elevation was recomputed (hill).
+        self.assertAlmostEqual(segs[-1]["end_mile"], round(self.total, 2), places=1)
+        self.assertGreater(sum(s["elevation_gain_ft"] for s in segs), 0)
+
+    def test_crew_and_drop_summaries(self):
+        with database.get_db() as conn:
+            result = self.race_engine.import_aid_stations(conn, self.stations, course_id=self.course_id)
+        self.assertEqual(result["crew_stations"], ["Quarter", "Half (turn)", "Finish"])
+        self.assertEqual(result["drop_bag_stations"], ["Half (turn)", "Three-Quarter", "Finish"])
+
+    def test_dry_run_does_not_write(self):
+        with database.get_db() as conn:
+            before = self.race_engine.get_segments(conn, self.course_id)
+            result = self.race_engine.import_aid_stations(
+                conn, self.stations, course_id=self.course_id, dry_run=True)
+            after = self.race_engine.get_segments(conn, self.course_id)
+        self.assertFalse(result["applied"])
+        # Segment rows are unchanged (still the original 5-mile buckets, unnamed).
+        self.assertEqual(len(after), len(before))
+        self.assertTrue(all(s["name"] is None for s in after))
+        # But the preview shows the rebuilt, named segments.
+        self.assertEqual(len(result["segments"]), 4)
+
+    def test_rebuild_is_idempotent_in_place(self):
+        with database.get_db() as conn:
+            self.race_engine.import_aid_stations(conn, self.stations, course_id=self.course_id)
+            self.race_engine.import_aid_stations(conn, self.stations, course_id=self.course_id)
+            courses = conn.execute("SELECT COUNT(*) FROM race_courses").fetchone()[0]
+            segs = self.race_engine.get_segments(conn, self.course_id)
+        # No duplicate course rows, and segments replaced (not appended).
+        self.assertEqual(courses, 1)
+        self.assertEqual(len(segs), 4)
+
+    def test_finish_short_of_course_end_snaps_to_end(self):
+        # Guide miles rarely match the GPX exactly (issue #18). Put the finish a
+        # mile short of the course end and confirm no extra unnamed tail segment
+        # appears and the finish segment is extended to the true end.
+        stations = [dict(s) for s in self.stations]
+        stations[-1]["mile"] = round(self.total - 1.0, 2)
+        with database.get_db() as conn:
+            result = self.race_engine.import_aid_stations(conn, stations, course_id=self.course_id)
+            segs = self.race_engine.get_segments(conn, self.course_id)
+        self.assertEqual(len(segs), 4)
+        self.assertEqual(segs[-1]["name"], "Finish")
+        self.assertAlmostEqual(segs[-1]["end_mile"], round(self.total, 2), places=1)
+        self.assertEqual(sum(1 for s in segs if s["name"] == "Finish"), 1)
+
+    def test_missing_gpx_raises(self):
+        with database.get_db() as conn:
+            conn.execute("UPDATE race_courses SET gpx_file_path = ? WHERE id = ?",
+                         ("/no/such/file.gpx", self.course_id))
+            with self.assertRaises(FileNotFoundError):
+                self.race_engine.import_aid_stations(conn, self.stations, course_id=self.course_id)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #18.

## What

Adds `ultra race load-aid-stations <csv>` — populates the previously-**unnamed** BR100 race segments with real aid-station names, crew-access, and drop-bag flags in one command, unblocking the crew manual (#12) and feeding the capstone strategy report (#16).

Previously segments were generic 5-mile buckets and the only way to name them was one-at-a-time `race segments --segment N --set-name ...` (23+ invocations). This adds a bulk, file-driven path.

## How

- **`backend/race_engine.py`** — `read_aid_stations_csv` + `build_aid_station_segments` + `import_aid_stations`:
  - Re-derives segments at the aid-station miles by re-parsing the loaded course's stored GPX (recomputing per-segment elevation/grade), names each segment after the station at its **end** mile (the convention the crew sheet already keys off), and sets crew/drop-bag flags from the chart.
  - **Replaces the course's segments in place** — no new course row, fixing the latent "`load-course` reload silently duplicates the course" gap.
  - **Snaps the finish to the true course end** so the guide-vs-GPX mile mismatch #18 warns about (~100.7 guide mi vs ~101.8 GPX mi) can't leave an unnamed tail segment mislabeled as a duplicate finish.
  - Counts and warns about saved splits/plans/check-ins that a rebuild would cascade-delete (FK `ON DELETE CASCADE`).
- **`backend/cli.py`** — `ultra race load-aid-stations FILE [--course-id] [--dry-run] [--json]` (subparser + dispatch). `--dry-run` previews the rebuilt segment table without writing; `--json` for agent consumption; errors emit `{"error","code"}` with exit 2.
- **`backend/data/br100_aid_stations_2026.csv`** — full 24-break BR100 chart transcribed from the **2026** participant guide (Aid Station Overview, REV 1/16/26): out-and-back, 4 AM start, 30-hr cutoff, ~101.8 mi. Cutoff times + food carried in the `notes` column for #12 to use later. Comment lines (`#`) carry provenance and are ignored by the reader.

## Test plan

- `python3 -m unittest discover -s backend/tests` → **27 passed** (8 new in `test_aid_stations.py`).
- New tests cover: CSV parsing incl. crew codes like `50/100` / `100`, comment-line skipping, name + crew/drop flag mapping onto the right segments, crew/drop summaries, dry-run writes nothing, in-place idempotency (no duplicate course, segments replaced not appended), finish-snap when the finish mile is short of the GPX end, and the missing-GPX error.
- Smoke-tested the CLI end-to-end against a synthetic GPX: `--help`, the no-course JSON error path, and the full human-readable run producing the correct 24 named segments with crew/drop flags.

## Notes for the reviewer

- The real BR100 GPX and DB are gitignored, so the mechanism was built and tested against a synthetic course; the maintainer runs the populate locally (`--dry-run` first).
- Aid-station miles/flags were transcribed from a photo of the 2026 guide — worth a spot-check, but they corroborate the crew/drop-bag lists in #18 exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UATRB1wFKdhHmgucQeVYZ5)_