### PR TITLE
Capstone: BR100 race strategy report synthesizing all signals (#16)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -189,6 +189,23 @@ python3 cli.py ultra race crew-manual --no-splits             # use the engine's
 # Defaults: --profile backend/data/br100_crew_protocol.yaml; goal/start from that profile;
 # splits from the bundled 2025 analog. Load the BR100 GPX first for grade-aware ETAs.
 
+# Capstone strategy report (issue #16): the meta-synthesis everything feeds into.
+# Agent-driven (mirrors aggregate-reports/peer-splits): the CLI gathers EVERY internal
+# signal — adaptive targets, own-history fade, the 26h peer cohort, the A/B/C plan, the
+# per-segment fueling math, crew/drop-bag flags, and the training block — into one JSON
+# "synthesis order"; the Claude Code session writes/updates the comprehensive strategy
+# report and files it to race-prep/. It is a LIVING document: re-run after each new long
+# run and it updates the SAME vault file in place (stable filename + Revision Log).
+python3 cli.py ultra race capstone --json                 # the synthesis dossier
+python3 cli.py ultra race capstone --weather-temp 82      # human-readable signal inventory
+python3 cli.py ultra race capstone --skeleton             # fillable section scaffold
+# After synthesizing, persist (stable filename = living doc; re-running updates in place):
+cat report.md | python3 cli.py ultra race capstone --save-guide - --json
+python3 cli.py ultra race capstone --save-guide report.md --date-prefix   # dated snapshot
+# Defaults: goal 26:00:00 governor, start 04:00, title "Burning River 100 Race Strategy".
+# When the report already exists, the dossier's method flips to "update in place" and asks
+# you to append a dated Revision Log entry noting what new data moved which numbers.
+
 # Live race tracking
 python3 cli.py ultra race checkin --station "Happy Days 2" --time "9:15:00" --json
 python3 cli.py ultra race status --json

--- a/backend/cli.py
+++ b/backend/cli.py
@@ -28,6 +28,7 @@ from .adapt import (
 from . import strava
 from . import race_engine
 from . import race_research
+from . import race_capstone
 from . import peer_splits
 from . import vault
 
@@ -2125,6 +2126,133 @@ def cmd_race_aggregate_reports(args):
               "`ultra race aggregate-reports --save-guide -` to file the guide.")
 
 
+def cmd_race_capstone(args):
+    """Capstone (#16): gather every signal into a dossier, or save the synthesized report.
+
+    Default: emit the structured synthesis dossier (the "synthesis order") — adaptive
+    targets, own-history fade, peer cohort, A/B/C plan, fueling, crew stations, and the
+    training block — that the Claude Code session turns into the comprehensive strategy
+    report. ``--save-guide PATH|-`` persists a finished markdown report to the vault under
+    a STABLE filename (living document; re-running updates it in place). ``--skeleton``
+    emits a fillable scaffold.
+    """
+    title = args.title or race_capstone.DEFAULT_TITLE
+
+    # --save-guide: persist an agent-produced report to the vault (no course needed).
+    if args.save_guide:
+        if args.save_guide == "-":
+            body = sys.stdin.read()
+        else:
+            try:
+                with open(args.save_guide, "r", encoding="utf-8") as f:
+                    body = f.read()
+            except OSError as e:
+                _err(f"Could not read report: {e}", args.json, 2)
+        if not body.strip():
+            _err("Report is empty — nothing to save.", args.json)
+        try:
+            res = vault.write_race_intel_to_vault(
+                title=title, body=body, doc_type="strategy-report",
+                date_prefix=args.date_prefix,
+            )
+        except vault.VaultError as e:
+            _err(str(e), args.json)
+        res["message"] = f"Strategy report written to {res['path']}"
+        _print(res, args.json)
+        return
+
+    goal_seconds = race_engine._parse_time(
+        args.goal_time or race_capstone.DEFAULT_TARGET_FINISH)
+
+    with get_db() as conn:
+        course = race_engine.get_course(conn)
+        if not course:
+            _err("No course loaded. Run: ultra race load-course <gpx> --name ... --year ...",
+                 args.json, 2)
+        course = dict(course)
+        plan = _get_plan(conn)
+        plan_id = plan["id"] if plan else None
+
+        dossier = race_capstone.build_capstone_dossier(
+            conn, course, plan_id=plan_id, goal_time_seconds=goal_seconds,
+            weather_temp_f=args.weather_temp, start_time=args.start_time or "05:00",
+            title=title,
+        )
+
+    if args.skeleton:
+        skeleton = race_capstone.render_capstone_skeleton(dossier)
+        if args.json:
+            _print({"skeleton": skeleton}, True)
+        else:
+            print(skeleton)
+        return
+
+    if args.json:
+        _print(dossier, True)
+        return
+
+    race = dossier["race"]
+    sig = dossier["signals"]
+    refs = dossier["references"]
+    print(f"=== {race['name']} ({race.get('year')}) — Capstone Synthesis Order ===")
+    gain = race.get("elevation_gain_ft")
+    dist = race.get("distance_miles")
+    meta = []
+    if dist:
+        meta.append(f"{dist:g} mi")
+    if gain:
+        meta.append(f"{gain:,.0f} ft")
+    if meta:
+        print(" · ".join(meta))
+    print(f"Governor {race['target_finish']} · {race['governor']}")
+    if race.get("weather_temp_f"):
+        print(f"Weather: {race['weather_temp_f']:g}°F")
+    print()
+    print(dossier["objective"])
+    print()
+
+    # Signal inventory — one line per signal so the operator sees what was gathered.
+    print("Signals gathered:")
+    t = sig.get("targets")
+    print(f"  ▸ Adaptive targets: "
+          + (f"easy {_fmt_pace(t['easy_pace'])}, long {_fmt_pace(t['long_run_pace'])}, "
+             f"MAF {t['maf_hr']} (eff. {t['effective_date']})" if t else "none on file"))
+    h = sig["history"]
+    print(f"  ▸ Own history: {h.get('count')} races, "
+          f"avg fade {h.get('avg_fade_pct')}% — {h.get('failure_mode') or 'no dominant mode'}")
+    pc = sig["peer_cohort"]
+    print(f"  ▸ Peer cohort: {pc.get('cohort_size')} finishers near {pc.get('goal_time')}, "
+          f"back-half slowdown {pc.get('slowdown_pct')}%, "
+          f"{len(pc.get('danger_zones') or [])} danger zone(s)")
+    rp = sig["race_plan"]
+    bands = " / ".join(f"{k}:{rp['plans'][k]['total_time_display']}" for k in ("A", "B", "C"))
+    print(f"  ▸ Race plan A/B/C: {bands}  (base {rp.get('base_pace_display')})")
+    print(f"  ▸ Fueling: {len(sig['fueling'])} segments costed")
+    print(f"  ▸ Crew/drop-bag stations: {len(sig['crew_stations'])}")
+    tb = sig["training_block"]
+    print(f"  ▸ Training block: {tb.get('count')} logged runs "
+          f"({len(tb.get('long_runs') or [])} long runs ≥18mi), latest {tb.get('latest_date')}")
+    print()
+
+    print("References to read:")
+    print(f"  report: {refs.get('report_path')} "
+          f"({'EXISTS — update in place' if refs.get('report_exists') else 'new — write fresh'})")
+    for key in ("course_guide", "peer_learnings", "crew_manual", "workouts_dir"):
+        print(f"  {key}: {refs[key]}")
+    print()
+
+    print("Method:")
+    for i, step in enumerate(dossier["method"], 1):
+        print(f"  {i}. {step}")
+    print()
+    print("Output sections:")
+    for section in dossier["output_sections"]:
+        print(f"  ▸ {section['heading']} — {section['what']}")
+    print()
+    print("Next: synthesize the report, then "
+          "`ultra race capstone --save-guide -` to file it (living document).")
+
+
 def cmd_export_md(args):
     import os
     from .ultra_plan import generate_training_plan_markdown
@@ -2458,6 +2586,26 @@ def main():
                        help="Prefix the saved filename with today's date (snapshot mode)")
     rar_p.add_argument("--json", action="store_true")
 
+    # ultra race capstone
+    rcp_p = race_sub.add_parser(
+        "capstone",
+        help="Capstone (#16): synthesize all signals into the BR100 strategy report")
+    rcp_p.add_argument("--goal-time", type=str,
+                       help="Governor finish time (HH:MM:SS, default 26:00:00)")
+    rcp_p.add_argument("--weather-temp", type=float,
+                       help="Forecast temperature (°F); escalates fueling/cooling")
+    rcp_p.add_argument("--start-time", type=str, default="05:00",
+                       help="Race start time (HH:MM, default 05:00)")
+    rcp_p.add_argument("--skeleton", action="store_true",
+                       help="Emit a fillable markdown scaffold of the report sections")
+    rcp_p.add_argument("--save-guide", type=str, metavar="PATH",
+                       help="Persist a finished markdown report to the vault ('-' for stdin)")
+    rcp_p.add_argument("--title", type=str,
+                       help="Report title / stable vault filename (default 'Burning River 100 Race Strategy')")
+    rcp_p.add_argument("--date-prefix", action="store_true",
+                       help="Prefix the saved filename with today's date (snapshot mode)")
+    rcp_p.add_argument("--json", action="store_true")
+
     # ultra race segments
     rsg_p = race_sub.add_parser("segments", help="View/edit course segments")
     rsg_p.add_argument("--segment", type=int, help="Segment number to edit")
@@ -2543,6 +2691,7 @@ def main():
                 "segments": cmd_race_segments,
                 "aggregate-reports": cmd_race_aggregate_reports,
                 "peer-splits": cmd_race_peer_splits,
+                "capstone": cmd_race_capstone,
             }
 
             cmd = race_commands.get(args.race_command)

--- a/backend/race_capstone.py
+++ b/backend/race_capstone.py
@@ -1,0 +1,310 @@
+"""Capstone — the BR100 meta-synthesis race-strategy report (issue #16).
+
+This is the deliverable everything else feeds into. Following the project's agent-driven
+pattern (CLAUDE.md), the CLI does **not** call an LLM to write the report. Instead it
+*gathers every internal signal the engine has already computed* — adaptive pace/HR
+targets, the athlete's own-history fade analysis, the peer-cohort split curve, the
+A/B/C race plan, the per-segment fueling schedule, the crew/drop-bag station flags, and
+a digest of the training block — into one structured **dossier**, and pairs it with a
+*synthesis order* (objective + method + output sections) that a Claude Code session
+executes to write or **update** the comprehensive strategy report.
+
+The report is persisted to the Obsidian vault via ``vault.write_race_intel_to_vault``
+under a STABLE filename, so re-running the command with fresh data (e.g. one more long
+run) updates the same **living document** in place rather than spawning a new file.
+
+Public surface:
+
+- ``build_capstone_dossier(conn, course, ...)`` — the gathered signal dossier + order.
+- ``render_capstone_skeleton(dossier)`` — a markdown scaffold of the output sections.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from . import race_engine
+from . import historical
+from . import vault
+from .adapt import get_current_targets
+
+
+DEFAULT_TARGET_FINISH = "26:00:00"
+DEFAULT_TITLE = "Burning River 100 Race Strategy"
+# 26h is the *governor* the whole plan paces to (sub-24 is a stretch only). Pull the
+# peer cohort within a 1-hour window of the governor so the back-half curve is grounded
+# in finishers who actually ran near the target.
+DEFAULT_WINDOW_SECONDS = 3600
+
+
+def _training_block_digest(conn, plan_id: int | None) -> dict[str, Any]:
+    """Summarize the logged training block from ``run_feedback``.
+
+    The rich narrative for each run lives in the vault (``workouts/``); here we surface
+    the structured facts the report's pacing/fueling math leans on — recent sessions,
+    the long-run capstones, and HR/elevation context.
+    """
+    if plan_id is None:
+        return {"count": 0, "sessions": [], "long_runs": [], "note": "No active plan."}
+
+    rows = conn.execute(
+        """SELECT rf.actual_distance_miles, rf.actual_pace, rf.avg_heart_rate,
+                  rf.max_heart_rate, rf.elevation_gain_ft, rf.effort_rating,
+                  rf.overall_feedback, w.date AS run_date, dw.title AS title
+           FROM run_feedback rf
+           JOIN workouts w ON w.id = rf.workout_id
+           LEFT JOIN daily_workouts dw ON dw.id = rf.daily_workout_id
+           WHERE rf.plan_id = ?
+           ORDER BY w.date DESC
+           LIMIT 20""",
+        (plan_id,),
+    ).fetchall()
+
+    sessions = []
+    for r in rows:
+        d = dict(r)
+        sessions.append({
+            "date": d.get("run_date"),
+            "title": d.get("title"),
+            "distance_miles": d.get("actual_distance_miles"),
+            "pace_display": race_engine._format_pace(d["actual_pace"] * 60)
+                if d.get("actual_pace") else None,
+            "avg_hr": d.get("avg_heart_rate"),
+            "max_hr": d.get("max_heart_rate"),
+            "elevation_gain_ft": d.get("elevation_gain_ft"),
+            "effort_rating": d.get("effort_rating"),
+        })
+
+    long_runs = [s for s in sessions
+                 if (s["distance_miles"] or 0) >= 18.0]
+
+    return {
+        "count": len(sessions),
+        "latest_date": sessions[0]["date"] if sessions else None,
+        "sessions": sessions,
+        "long_runs": long_runs,
+        "note": ("Structured facts only — read the per-run narrative in the vault "
+                 "`workouts/` notes and `PRODUCT_LOG.md` for the qualitative picture."),
+    }
+
+
+def _vault_references(course_name: str, title: str) -> dict[str, Any]:
+    """Vault docs the synthesizing agent should read for narrative depth."""
+    refs: dict[str, Any] = {
+        "report_path": None,
+        "report_exists": False,
+        "course_guide": f"race-prep/{course_name} Course & Strategy Guide.md",
+        "peer_learnings": f"race-prep/{course_name} Peer Split Learnings.md",
+        "crew_manual": f"race/{course_name} Crew Manual.md",
+        "workouts_dir": "workouts/  (per-run narrative + Mohican benchmark report)",
+        "product_log": "workouts/PRODUCT_LOG.md",
+        "memory": "Workout App memory: Mohican benchmark, fueling protocol, course guide notes.",
+    }
+    try:
+        path = vault.race_intel_target_path(title)
+        refs["report_path"] = str(path)
+        refs["report_exists"] = path.exists()
+    except vault.VaultError:
+        pass
+    return refs
+
+
+def _output_sections() -> list[dict[str, str]]:
+    """The sections the synthesized capstone report must contain (issue #16 Output)."""
+    return [
+        {"heading": "Executive Summary & Goal",
+         "what": "Finish-primary framing: 26h governor (sub-24 a stretch only). The one "
+                 "paragraph the athlete re-reads at mile 70 — the race in a nutshell."},
+        {"heading": "Segment-by-Segment Pacing Plan (26h)",
+         "what": "Every segment/aid station: target pace, segment time, cumulative "
+                 "elapsed, and clock ETA — biased to a negative split given the own-history "
+                 "fade and the peer back-half slowdown. Flag the danger-zone segments."},
+        {"heading": "Fueling & Sodium Schedule",
+         "what": "Per-segment: gels every 30–40 min between aid, ~60–70 g carb/hr, "
+                 "~500–700 mg sodium/hr. Bake in the Mohican lesson (drop HEED-as-primary; "
+                 "use the athlete's Flash IV + NeverSecond protocol). Heat escalation."},
+        {"heading": "Walk/Run & Power-Hike Strategy",
+         "what": "Where to run, where to power-hike the climbs, and the run/walk cadence "
+                 "for the towpath and the night sections. Concrete rules, not vibes."},
+        {"heading": "Crew Plan & Drop-Bag Contents",
+         "what": "Per crew-accessible station: ETA window, what crew does, and exact "
+                 "drop-bag contents (night kit, shoes/socks, fuel restock, cooling)."},
+        {"heading": "Contingencies — Heat, Night & Low Patches",
+         "what": "Explicit if/then plans. Anchor on the Canal Corridor weather-DNF lesson: "
+                 "do NOT let bad overnight weather end the race mentally. Heat, GI, dark-"
+                 "patch, and behind-pace playbooks."},
+        {"heading": "Lessons Integrated",
+         "what": "Trace each pacing/fueling decision back to its signal — own-history fade, "
+                 "peer cohort, Mohican benchmark, training block — so the plan is auditable."},
+        {"heading": "Revision Log",
+         "what": "Living-document changelog: dated entries noting what new data (which run) "
+                 "moved which numbers. Append on every regeneration; never overwrite."},
+    ]
+
+
+def _method(existing: bool) -> list[str]:
+    """Synthesis steps the executing agent should follow."""
+    steps = []
+    if existing:
+        steps.append(
+            "UPDATE the existing report in place (it is linked under `references.report_path`): "
+            "read it first, preserve its structure and narrative voice, revise the numbers from "
+            "this dossier, and add a dated entry to the Revision Log describing what changed.")
+    else:
+        steps.append(
+            "Write the report fresh from the output sections below; seed an empty Revision Log "
+            "with today's dated 'initial draft' entry.")
+    steps += [
+        "Read the linked vault docs for narrative depth before writing: the course guide, the "
+        "peer-split learnings, the Mohican benchmark note, and the recent `workouts/` reports.",
+        "Build the segment pacing table from `signals.race_plan` — pick the scenario aligned to "
+        "the 26h governor as primary; keep A/B/C as the aggressive/governor/survival bands.",
+        "Bias the pace curve to a negative split: weight the back-half toward the own-history "
+        "fade (`signals.history.avg_fade_pct`) and the peer cohort slowdown "
+        "(`signals.peer_cohort.slowdown_pct`); call out the danger-zone segments explicitly.",
+        "Cross-check the fueling schedule against the athlete's logged protocol and the Mohican "
+        "HEED lesson — do not invent products; reconcile g/hr and mg/hr against `signals.fueling`.",
+        "Keep every claim traceable to a signal in this dossier or a cited vault doc; flag any "
+        "gap the data cannot close rather than papering over it.",
+        "Save with `ultra race capstone --save-guide -` (markdown on stdin) — stable filename, so "
+        "the living document is updated in place.",
+    ]
+    return steps
+
+
+def build_capstone_dossier(
+    conn,
+    course: dict,
+    *,
+    plan_id: int | None = None,
+    goal_time_seconds: int,
+    window_seconds: int = DEFAULT_WINDOW_SECONDS,
+    weather_temp_f: float | None = None,
+    start_time: str = "05:00",
+    weight_lbs: float | None = None,
+    title: str = DEFAULT_TITLE,
+) -> dict[str, Any]:
+    """Gather every internal signal into a dossier + synthesis order for issue #16.
+
+    ``course`` is a row dict from ``race_engine.get_course``. The returned dict is fully
+    JSON-serializable: a ``race`` header, a ``signals`` block (targets, history, peer
+    cohort, race plan, fueling, crew stations, training block), ``references`` to the
+    vault docs to read, and the ``objective`` / ``method`` / ``output_sections`` that
+    tell the agent how to write or update the report.
+    """
+    course_id = course["id"]
+    goal_display = race_engine._format_time(goal_time_seconds)
+
+    # --- adaptive targets -------------------------------------------------
+    targets = get_current_targets(conn, plan_id) if plan_id else None
+
+    # --- own-history fade analysis ----------------------------------------
+    history = historical.analyze_history(conn)
+
+    # --- peer cohort split curve ------------------------------------------
+    cohort = race_engine.analyze_cohort(conn, course_id, goal_time_seconds, window_seconds)
+
+    # --- A/B/C race plan ---------------------------------------------------
+    race_plan = race_engine.generate_race_plan(
+        conn, course_id, plan_id, goal_time_seconds,
+        weather_temp_f=weather_temp_f, start_time=start_time)
+
+    # --- per-segment fueling (off the A scenario) -------------------------
+    a_segments = race_plan["plans"]["A"]["segments"]
+    fueling = race_engine.generate_fueling_plan(
+        conn, course_id, a_segments,
+        weight_lbs=weight_lbs or race_engine.DEFAULT_WEIGHT_LBS)
+
+    # --- crew / drop-bag stations -----------------------------------------
+    segments = race_engine.get_segments(conn, course_id)
+    crew_stations = [
+        {
+            "segment_number": s["segment_number"],
+            "name": s.get("name") or f"Mile {s['start_mile']:.1f}",
+            "mile": round(s["end_mile"], 1),
+            "crew_accessible": bool(s.get("crew_accessible")),
+            "drop_bag": bool(s.get("drop_bag")),
+            "terrain_notes": s.get("terrain_notes"),
+        }
+        for s in segments
+        if s.get("crew_accessible") or s.get("drop_bag")
+    ]
+
+    # --- training block digest --------------------------------------------
+    training_block = _training_block_digest(conn, plan_id)
+
+    references = _vault_references(course["name"], title)
+
+    dossier: dict[str, Any] = {
+        "race": {
+            "name": course["name"],
+            "year": course.get("year"),
+            "distance_miles": course.get("total_distance_miles"),
+            "elevation_gain_ft": course.get("total_elevation_gain_ft"),
+            "target_finish": goal_display,
+            "governor": "26h finish-primary; sub-24 is a stretch only",
+            "weather_temp_f": weather_temp_f,
+            "start_time": start_time,
+        },
+        "objective": (
+            f"Synthesize every signal below into ONE comprehensive {course['name']} "
+            f"race-strategy report paced to a {goal_display} governor. This is the capstone "
+            "(issue #16): segment pacing, fueling/sodium, walk/run + power-hiking, crew & "
+            "drop-bag plan, and heat/night/low-patch contingencies — all traceable to the "
+            "data. It is a LIVING document: re-running this command with new data updates "
+            "the same vault file in place."
+        ),
+        "signals": {
+            "targets": dict(targets) if targets else None,
+            "history": {
+                "count": history.get("count"),
+                "failure_mode": history.get("failure_mode"),
+                "avg_fade_pct": history.get("avg_fade_pct"),
+                "positive_split_count": history.get("positive_split_count"),
+                "dnf_count": history.get("dnf_count"),
+                "lessons": history.get("lessons"),
+                "training_implications": history.get("training_implications"),
+                "races": history.get("races"),
+            },
+            "peer_cohort": cohort,
+            "race_plan": race_plan,
+            "fueling": fueling,
+            "crew_stations": crew_stations,
+            "training_block": training_block,
+        },
+        "references": references,
+        "method": _method(references.get("report_exists", False)),
+        "output_sections": _output_sections(),
+    }
+    return dossier
+
+
+def render_capstone_skeleton(dossier: dict[str, Any]) -> str:
+    """Render a markdown scaffold of the report's output sections.
+
+    A fallback artifact / fill-in scaffold; the real content is the agent's synthesis of
+    the dossier signals, not this function.
+    """
+    race = dossier["race"]
+    lines: list[str] = []
+    lines.append(f"# {race['name']} — Race Strategy")
+    lines.append("")
+    meta_bits = [str(race.get("year") or "")]
+    if race.get("distance_miles"):
+        meta_bits.append(f"{race['distance_miles']:g} mi")
+    if race.get("elevation_gain_ft"):
+        meta_bits.append(f"{race['elevation_gain_ft']:,.0f} ft climb")
+    meta_bits.append(f"governor {race.get('target_finish')}")
+    if race.get("weather_temp_f"):
+        meta_bits.append(f"{race['weather_temp_f']:g}°F")
+    lines.append("*" + " · ".join(b for b in meta_bits if b) + "*")
+    lines.append("")
+    lines.append("> Skeleton only — synthesize each section from the dossier "
+                 "(`ultra race capstone --json`).")
+    lines.append("")
+    for section in dossier["output_sections"]:
+        lines.append(f"## {section['heading']}")
+        lines.append("")
+        lines.append(f"_{section['what']}_")
+        lines.append("")
+    return "\n".join(lines).rstrip() + "\n"

--- a/backend/tests/test_capstone.py
+++ b/backend/tests/test_capstone.py
@@ -1,0 +1,165 @@
+"""Tests for the capstone synthesis dossier (#16).
+
+Run with: ``python3 -m unittest backend.tests.test_capstone -v`` from repo root.
+
+Uses a throwaway SQLite file + synthetic GPX so the real ``workouts.db`` is never
+touched. The capstone CLI does no LLM work — it gathers every internal signal into a
+JSON-serializable dossier + synthesis order — so the tests assert the dossier shape,
+that signals are wired through, and that the living-document path detection flips the
+synthesis method between "write fresh" and "update in place".
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from backend import database, historical, race_capstone, race_engine, vault
+
+
+def _write_synthetic_gpx(path, n=200, lat0=40.0, lon0=-81.5):
+    pts = []
+    for i in range(n + 1):
+        lat = lat0 + i * 0.0009
+        ele = 300 + 200 * math.sin(math.pi * i / n)
+        pts.append(f'<trkpt lat="{lat:.6f}" lon="{lon0:.6f}"><ele>{ele:.1f}</ele></trkpt>')
+    gpx = (
+        '<?xml version="1.0" encoding="UTF-8"?>\n'
+        '<gpx version="1.1" creator="test"><trk><trkseg>\n'
+        + "\n".join(pts) + "\n</trkseg></trk></gpx>\n"
+    )
+    with open(path, "w") as f:
+        f.write(gpx)
+
+
+class CapstoneTestCase(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+        self._tmp.close()
+        self._patcher = patch.object(database, "DB_PATH", self._tmp.name)
+        self._patcher.start()
+        database.init_db()
+
+        self._gpx = tempfile.NamedTemporaryFile(suffix=".gpx", delete=False)
+        self._gpx.close()
+        _write_synthetic_gpx(self._gpx.name)
+
+        with database.get_db() as conn:
+            cid, segs, total, gain = race_engine.load_course(
+                conn, self._gpx.name, "Test Course", 2026)
+            self.course_id = cid
+            self.total = total
+            stations = [
+                {"mile": round(total * 0.25, 2), "name": "Q1", "crew": True, "drop_bag": False, "notes": None},
+                {"mile": round(total * 0.50, 2), "name": "Turn", "crew": True, "drop_bag": True, "notes": None},
+                {"mile": round(total * 0.75, 2), "name": "Q3", "crew": False, "drop_bag": False, "notes": None},
+                {"mile": round(total, 2), "name": "Finish", "crew": True, "drop_bag": True, "notes": None},
+            ]
+            race_engine.import_aid_stations(conn, stations, course_id=cid)
+            # A prior race so the own-history fade signal is non-empty.
+            historical.add_race(
+                conn, name="Prior 100", race_date="2024-08-01",
+                distance_miles=100.0, elevation_gain_ft=8000.0,
+                finish_time_seconds=24 * 3600,
+                first_half_seconds=11 * 3600, second_half_seconds=13 * 3600,
+                terrain="trail", notes="positive split")
+
+    def tearDown(self):
+        self._patcher.stop()
+        os.unlink(self._tmp.name)
+        os.unlink(self._gpx.name)
+
+    def _course(self, conn):
+        return dict(race_engine.get_course(conn, self.course_id))
+
+    def test_dossier_shape_and_signals(self):
+        with database.get_db() as conn:
+            dossier = race_capstone.build_capstone_dossier(
+                conn, self._course(conn), plan_id=None,
+                goal_time_seconds=26 * 3600, weather_temp_f=80.0)
+
+        # Fully JSON-serializable (the CLI emits it via _print).
+        json.dumps(dossier)
+
+        self.assertEqual(set(dossier), {
+            "race", "objective", "signals", "references", "method", "output_sections"})
+        sig = dossier["signals"]
+        self.assertEqual(set(sig), {
+            "targets", "history", "peer_cohort", "race_plan",
+            "fueling", "crew_stations", "training_block"})
+
+        # History wired through.
+        self.assertEqual(sig["history"]["count"], 1)
+        self.assertIsNotNone(sig["history"]["avg_fade_pct"])
+
+        # A/B/C plan with per-segment rows; fueling costs every segment.
+        for band in ("A", "B", "C"):
+            self.assertIn(band, sig["race_plan"]["plans"])
+        with database.get_db() as conn:
+            n_segments = len(race_engine.get_segments(conn, self.course_id))
+        self.assertEqual(len(sig["fueling"]), n_segments)
+        self.assertEqual(len(sig["race_plan"]["plans"]["A"]["segments"]), n_segments)
+
+        # Only crew/drop-bag stations are surfaced (Q3 is neither).
+        names = {s["name"] for s in sig["crew_stations"]}
+        self.assertIn("Turn", names)
+        self.assertNotIn("Q3", names)
+        for s in sig["crew_stations"]:
+            self.assertTrue(s["crew_accessible"] or s["drop_bag"])
+
+        # No plan → targets/training block degrade gracefully.
+        self.assertIsNone(sig["targets"])
+        self.assertEqual(sig["training_block"]["count"], 0)
+
+        # Weather + governor framing carried in the header.
+        self.assertEqual(dossier["race"]["weather_temp_f"], 80.0)
+        self.assertEqual(dossier["race"]["target_finish"], "26:00:00")
+
+    def test_output_sections_cover_issue_16(self):
+        with database.get_db() as conn:
+            dossier = race_capstone.build_capstone_dossier(
+                conn, self._course(conn), plan_id=None, goal_time_seconds=26 * 3600)
+        headings = " ".join(s["heading"].lower() for s in dossier["output_sections"])
+        for needle in ("pacing", "fueling", "walk", "crew", "conting", "revision"):
+            self.assertIn(needle, headings)
+
+    def test_skeleton_renders(self):
+        with database.get_db() as conn:
+            dossier = race_capstone.build_capstone_dossier(
+                conn, self._course(conn), plan_id=None, goal_time_seconds=26 * 3600)
+        md = race_capstone.render_capstone_skeleton(dossier)
+        self.assertIn("# Test Course — Race Strategy", md)
+        self.assertIn("## Revision Log", md)
+
+    def test_living_document_method_flips_on_existing_report(self):
+        with tempfile.TemporaryDirectory() as vault_root:
+            with patch.dict(os.environ, {"OBSIDIAN_VAULT_PATH": vault_root}):
+                title = "Test Course Race Strategy"
+                with database.get_db() as conn:
+                    course = self._course(conn)
+                    fresh = race_capstone.build_capstone_dossier(
+                        conn, course, plan_id=None, goal_time_seconds=26 * 3600,
+                        title=title)
+                self.assertFalse(fresh["references"]["report_exists"])
+                self.assertIn("Write the report fresh", fresh["method"][0])
+
+                # Simulate a prior save, then re-gather: method must switch to update.
+                vault.write_race_intel_to_vault(
+                    title=title, body="# prior\n", doc_type="strategy-report")
+                self.assertTrue(vault.race_intel_target_path(title).exists())
+
+                with database.get_db() as conn:
+                    again = race_capstone.build_capstone_dossier(
+                        conn, self._course(conn), plan_id=None,
+                        goal_time_seconds=26 * 3600, title=title)
+                self.assertTrue(again["references"]["report_exists"])
+                self.assertIn("UPDATE the existing report", again["method"][0])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/vault.py
+++ b/backend/vault.py
@@ -444,6 +444,23 @@ def _race_frontmatter(doc_date: str, doc_type: str) -> str:
     )
 
 
+def race_intel_target_path(
+    title: str, *, date_prefix: bool = False, doc_date: str | None = None
+):
+    """Return the ``race-prep/`` path a race-intel doc with ``title`` would be written to.
+
+    Lets callers check whether a doc already exists (e.g. the capstone living document)
+    without writing. Raises ``VaultError`` if the vault path is unusable. Mirrors the
+    filename logic in :func:`write_race_intel_to_vault`.
+    """
+    race_prep_dir = _race_prep_dir()
+    doc_date = doc_date or datetime.now().strftime("%Y-%m-%d")
+    title_segment = re.sub(r"[\\/:*?\"<>|]", "", (title or "").strip()) or "Race Intel"
+    title_segment = re.sub(r"\s+", " ", title_segment)
+    stem = f"{doc_date} {title_segment}" if date_prefix else title_segment
+    return race_prep_dir / (stem.strip() + ".md")
+
+
 def write_race_intel_to_vault(
     *,
     title: str,
@@ -468,15 +485,12 @@ def write_race_intel_to_vault(
     Returns ``{"path": <absolute md path>, "method": "oj"|"direct", "filename": ...}``.
     Raises ``VaultError`` if the vault path itself is unusable.
     """
-    race_prep_dir = _race_prep_dir()  # raises VaultError if env unset/missing
+    _race_prep_dir()  # raises VaultError if env unset/missing
 
     doc_date = doc_date or datetime.now().strftime("%Y-%m-%d")
     # Preserve the author's casing (e.g. "BR100"); only strip filesystem-illegal chars.
-    title_segment = re.sub(r"[\\/:*?\"<>|]", "", (title or "").strip()) or "Race Intel"
-    title_segment = re.sub(r"\s+", " ", title_segment)
-    stem = f"{doc_date} {title_segment}" if date_prefix else title_segment
-    filename = stem.strip() + ".md"
-    target = race_prep_dir / filename
+    target = race_intel_target_path(title, date_prefix=date_prefix, doc_date=doc_date)
+    filename = target.name
 
     framed = _race_frontmatter(doc_date, doc_type) + body.rstrip() + "\n"
 


### PR DESCRIPTION
The meta-synthesis deliverable (issue #16). `ultra race capstone` brings every prior race-day signal together into one comprehensive, living BR100 strategy report.

## What it does
Agent-driven, mirroring `aggregate-reports`/`peer-splits`: the CLI gathers **every internal signal** into a JSON **synthesis dossier** + an `objective`/`method`/`output_sections` order; the Claude Code session writes the report and files it with `--save-guide -`.

Signals gathered:
- Adaptive pace/HR targets
- Own-history fade analysis (#13)
- 26h peer cohort split curve (#14)
- A/B/C race plan + per-segment fueling
- Crew/drop-bag station flags
- Training-block digest (run reports + Mohican benchmark)

## Living document
`--save-guide` writes to `race-prep/Burning River 100 Race Strategy.md` under a **stable filename**. Re-running after new data (e.g. the final long run) updates the same file in place, and the dossier's `method` flips to *"update in place"* + append a dated **Revision Log** entry once the report exists (via new `vault.race_intel_target_path()`).

## Notes
- `--skeleton`, `--date-prefix`, `--weather-temp`, `--goal-time` (26:00 governor default) supported.
- First draft already filed to the vault.
- 4 new tests in `test_capstone.py`; **54 total pass**.

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)