### PR TITLE
Flag cohort danger zones by relative CV, not absolute 60s stdev (#23)

### DIFF
--- a/backend/peer_splits.py
+++ b/backend/peer_splits.py
@@ -392,17 +392,11 @@ def peer_learnings_markdown(analysis: dict, cohort: list[dict], goal_display: st
                      "and `peer-splits --import` first.")
         return "\n".join(lines) + "\n"
 
-    # Flag divergence RELATIVELY (coefficient of variation = stdev / median pace), not by
-    # the engine's absolute 60s threshold — at 15+ min/mi ultra pace every segment trips an
-    # absolute cutoff. A segment is a "divergence point" if its CV is in the cohort's top
-    # quartile: that's where finishers actually separate.
+    # The engine flags divergence RELATIVELY (top-quartile coefficient of variation),
+    # so consume its danger_zone flags directly rather than recomputing the cut here.
     scored = [s for s in analysis["segments"] if s.get("median_pace_seconds")]
-    for s in scored:
-        sd_s = s.get("pace_stdev_seconds") or 0
-        s["_cv"] = sd_s / s["median_pace_seconds"] if s["median_pace_seconds"] else 0
-    cvs = sorted((s["_cv"] for s in scored), reverse=True)
-    cv_cut = cvs[max(0, len(cvs) // 4 - 1)] if cvs else 0
-    diverge = [s for s in scored if s["_cv"] >= cv_cut and s["_cv"] > 0]
+    diverge = sorted((s for s in scored if s.get("danger_zone")),
+                     key=lambda s: -(s.get("pace_cv") or 0))
 
     lines += [
         f"**Finish range:** {analysis['fastest_finish']} – {analysis['slowest_finish']} "
@@ -417,7 +411,7 @@ def peer_learnings_markdown(analysis: dict, cohort: list[dict], goal_display: st
                      f"{sd}% slower than the first half. Plan for it; don't fight it.")
     if diverge:
         names = ", ".join(f"{s['segment_name']} (seg {s['segment_number']})"
-                          for s in sorted(diverge, key=lambda x: -x["_cv"])[:6])
+                          for s in diverge[:6])
         lines.append(f"- **Highest-divergence segments (where finishes separate most):** {names}. "
                      "Execute these deliberately — they decide the day more than the average mile.")
     lines += ["", "## Pacing skeleton (median per-segment)", "",

--- a/backend/race_engine.py
+++ b/backend/race_engine.py
@@ -508,8 +508,12 @@ def analyze_cohort(conn, course_id, goal_time_seconds, window_seconds=3600):
                 "median_pace_display": _format_pace(median_pace),
                 "median_time_seconds": int(median_time),
                 "pace_stdev_seconds": round(pace_stdev, 1),
+                # Coefficient of variation (stdev relative to pace) is the comparable
+                # divergence metric; the absolute danger_zone flag is set in a second
+                # pass below once every segment's CV is known.
+                "pace_cv": round(pace_stdev / median_pace, 4) if median_pace else 0.0,
                 "sample_size": len(paces),
-                "danger_zone": pace_stdev > 60,  # high variance = danger
+                "danger_zone": False,
             }
         else:
             stat = {
@@ -520,10 +524,17 @@ def analyze_cohort(conn, course_id, goal_time_seconds, window_seconds=3600):
                 "median_pace_display": "N/A",
                 "median_time_seconds": None,
                 "pace_stdev_seconds": None,
+                "pace_cv": None,
                 "sample_size": 0,
                 "danger_zone": False,
             }
         segment_stats.append(stat)
+
+    # Flag danger zones RELATIVELY: a segment is a danger zone when its coefficient
+    # of variation (pace_stdev / median_pace) lands in the cohort's top quartile.
+    # An absolute stdev cutoff (the old `pace_stdev > 60`) trips on nearly every
+    # segment at 15+ min/mi ultra pace, where >60s spread is normal (issue #23).
+    danger_zones = _flag_danger_zones(segment_stats)
 
     # Identify slowdown curve: how much did the cohort slow in back half?
     first_half = [s for s in segment_stats
@@ -546,9 +557,30 @@ def analyze_cohort(conn, course_id, goal_time_seconds, window_seconds=3600):
         "fastest_finish": _format_time(min(finish_times)),
         "slowest_finish": _format_time(max(finish_times)),
         "slowdown_pct": slowdown_pct,
-        "danger_zones": [s["segment_name"] for s in segment_stats if s["danger_zone"]],
+        "danger_zones": danger_zones,
         "segments": segment_stats,
     }
+
+
+def _flag_danger_zones(segment_stats):
+    """Mark the cohort's highest-divergence segments by coefficient of variation.
+
+    Mutates each segment dict's ``danger_zone`` flag in place and returns the
+    danger-zone segment names ordered by descending CV (most divergent first).
+
+    A segment is flagged when its CV is in the top quartile of the cohort, so the
+    signal scales with pace instead of tripping on every segment at ultra pace.
+    """
+    scored = [s for s in segment_stats if s.get("pace_cv")]
+    if not scored:
+        return []
+    cvs = sorted((s["pace_cv"] for s in scored), reverse=True)
+    cv_cut = cvs[max(0, len(cvs) // 4 - 1)]
+    diverge = sorted((s for s in scored if s["pace_cv"] >= cv_cut),
+                     key=lambda s: -s["pace_cv"])
+    for s in diverge:
+        s["danger_zone"] = True
+    return [s["segment_name"] for s in diverge]
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_peer_splits.py
+++ b/backend/tests/test_peer_splits.py
@@ -221,6 +221,55 @@ class PeerSplitsTestCase(unittest.TestCase):
         self.assertEqual(n, 0)
         self.assertTrue(any("disagrees" in w for w in res["warnings"]))
 
+    # --- relative danger zones (#23) ----------------------------------------
+    def test_danger_zones_are_relative_not_every_segment(self):
+        # Three finishers near 4:00. Splits are tight on every leg EXCEPT Q3, where
+        # the cohort diverges hard. Under the old absolute `stdev > 60` rule every
+        # 15+ min/mi leg would flag; the relative top-quartile CV should isolate Q3.
+        q1 = round(self.total * 0.25, 2)
+        half = round(self.total * 0.50, 2)
+        q3 = round(self.total * 0.75, 2)
+        full = round(self.total, 2)
+        rows = ["runner_name,finish_time,dnf,mat_mile,mat_name,elapsed,year,source"]
+        # Q3 elapsed varies wildly across runners; all other mats are near-identical.
+        q3_elapseds = ["2:50:00", "3:10:00", "3:30:00"]
+        for name, q3e in zip("ABC", q3_elapseds):
+            rows += [
+                f"{name},4:00:00,0,{q1},Q1,1:00:00,2025,ultrasignup",
+                f"{name},4:00:00,0,{half},Turn,2:00:00,2025,ultrasignup",
+                f"{name},4:00:00,0,{q3},Q3,{q3e},2025,ultrasignup",
+                f"{name},4:00:00,0,{full},Finish,4:00:00,2025,ultrasignup",
+            ]
+        csv = self._write_csv("\n".join(rows) + "\n")
+        with database.get_db() as conn:
+            peer_splits.import_peer_splits_long(conn, self.course_id, csv, default_year=2025)
+            analysis = race_engine.analyze_cohort(conn, self.course_id, 4 * 3600, 3600)
+        scored = [s for s in analysis["segments"] if s["median_pace_seconds"]]
+        flagged = analysis["danger_zones"]
+        # Top quartile of 4 segments = 1 — NOT every segment, which is the #23 fix.
+        self.assertEqual(len(flagged), 1)
+        self.assertLess(len(flagged), len(scored))
+        # The flagged segment is the genuine highest-CV (most divergent) leg, and the
+        # tight early legs (Q1/Turn, identical splits) are not flagged.
+        top = max(scored, key=lambda s: s["pace_cv"])
+        self.assertEqual(flagged, [top["segment_name"]])
+        by_name = {s["segment_name"]: s for s in analysis["segments"]}
+        self.assertFalse(by_name["Q1"]["danger_zone"])
+        self.assertFalse(by_name["Turn"]["danger_zone"])
+
+    def test_flag_danger_zones_orders_by_cv_and_handles_empty(self):
+        segs = [
+            {"segment_name": "lo", "pace_cv": 0.02, "danger_zone": False},
+            {"segment_name": "hi", "pace_cv": 0.20, "danger_zone": False},
+            {"segment_name": "mid", "pace_cv": 0.10, "danger_zone": False},
+            {"segment_name": "gap", "pace_cv": None, "danger_zone": False},
+        ]
+        names = race_engine._flag_danger_zones(segs)
+        self.assertEqual(names, ["hi"])               # top quartile of 3 scored = 1
+        self.assertTrue(segs[1]["danger_zone"])
+        # No scored segments → no flags, no crash.
+        self.assertEqual(race_engine._flag_danger_zones([{"pace_cv": None}]), [])
+
     # --- research order -----------------------------------------------------
     def test_research_order_maps_mats_and_lists_schema(self):
         course = {"name": "Test Course", "year": 2026, "total_distance_miles": self.total}


### PR DESCRIPTION
## Problem

`race_engine.analyze_cohort` marked a segment as a danger zone when `pace_stdev_seconds > 60`. At 100-mile pace (15+ min/mi), normal per-segment pace variance across a cohort is routinely >60s, so **nearly every segment tripped the flag**. On the real 2025 BR100 cohort (8 finishers, PR #22), `race cohort --goal-time 26:00:00` listed ~all 22 segments as danger zones — useless signal.

## Fix

Make the threshold **relative**: a segment is a danger zone when its coefficient of variation (`stdev / median_pace`) lands in the cohort's top quartile — the same approach the `#14` `peer-splits --learnings` report used as a local workaround, now promoted into the engine.

- `analyze_cohort` computes `pace_cv` per segment and sets `danger_zone` flags in a second pass (`_flag_danger_zones`), returning `danger_zones` ordered by descending divergence.
- `peer_splits.peer_learnings_markdown` drops its local CV computation and just consumes the engine's `danger_zone` flags, so `race cohort` and `peer-splits` stay in sync.

## Result on the real 2025 cohort

Before: ~all 22 segments flagged. After: **6 of 24** — the final-10mi out-and-back return legs (Schumacher / North Hawkins appear twice) where finishers actually separate.

## Tests

- `test_danger_zones_are_relative_not_every_segment` — integration: only the top-quartile (most divergent) leg flags; tight early legs do not.
- `test_flag_danger_zones_orders_by_cv_and_handles_empty` — unit: CV ordering + empty/None-CV handling.
- Full suite: 56 passing.

Closes #23.

🤖 Generated with [Claude Code](https://claude.com/claude-code)