### PR TITLE
Mental-state tracking on runs (issue #9, piece 1 of 4)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,6 +43,26 @@ python3 cli.py ultra submit --distance 10 --duration 100 --hr 140 \
 
 Proactively remind about fuel for runs >60 min. Treat bonking or GI reports as high-priority coaching moments — these are critical for race-day preparation.
 
+## Mental Training Tracking (Issue #9, piece 1 of 4)
+
+Mental energy management is treated as a **peer dimension** to fitness and economy — not a soft add-on. Mental state and cardiac output are directly coupled (a scattered mind raises HR at constant pace; calm focus lowers it). When generating a run report, **ask about mental state** alongside nutrition:
+
+1. **Intention (pre-run target)**: What mindset did you set out to practice? (e.g. box breathing on climbs, staying present)
+2. **State**: calm / focused / scattered / stressed / flow
+3. **Breathing**: relaxed / forced / erratic
+4. **Mind-wandering**: yes / no / sometimes
+
+Pass responses via CLI flags on `submit`; they're stored on `run_feedback`, woven into AI coaching (`mental_feedback`), and rendered in a `## Mental` section of the vault note:
+
+```bash
+python3 cli.py ultra submit --distance 10 --duration 100 --hr 140 \
+  --mental-intention "box breathing on climbs" --mental-state flow \
+  --breathing-quality relaxed --mind-wandering no \
+  --mental-notes "HR dropped whenever I focused on breath"
+```
+
+The coaching lens: the ultra mental tools are **pre-loaded then deployed** (rehearsed visualization, pre-written mantras like "Calm is strong", pain reframes like "burning quads = info, not a stop sign"). Reinforce practicing them on training runs so they're automatic by race day, and coach prescribed-vs-actual when an `--mental-intention` was set. Remaining pieces of #9 (still to build): weekly mental prescriptions, race-day mental rehearsal, and HR-at-pace × mental-state correlation analysis.
+
 ## Schedule Adjustments
 
 The markdown (`TRAINING_PLAN.md`) is the reference plan. Small day-to-day shifts (e.g., doing Wednesday's tempo on Thursday) don't need formal tracking — just note them in the run report. When submitting a shifted workout via CLI, use `--scheduled-date` to match the right prescribed workout:

--- a/backend/cli.py
+++ b/backend/cli.py
@@ -235,7 +235,9 @@ def _submit_run(distance, duration=None, hr=None, max_hr=None, elevation=None,
                 effort=None, pace=None, notes="", source="cli", run_date=None,
                 skip_feedback=False, strava_activity_id=None, as_json=False,
                 pre_meal=None, during_fuel=None, during_hydration=None,
-                post_meal=None, nutrition_notes=None, scheduled_date=None,
+                post_meal=None, nutrition_notes=None,
+                mental_state=None, breathing_quality=None, mind_wandering=None,
+                mental_intention=None, mental_notes=None, scheduled_date=None,
                 skip_vault=False):
     """Core run submission logic. Returns result dict.
 
@@ -362,10 +364,20 @@ def _submit_run(distance, duration=None, hr=None, max_hr=None, elevation=None,
             "nutrition_notes": nutrition_notes,
         }
 
+    mental_data = None
+    if any(v is not None for v in (mental_state, breathing_quality, mind_wandering, mental_intention, mental_notes)):
+        mental_data = {
+            "mental_state": mental_state,
+            "breathing_quality": breathing_quality,
+            "mind_wandering": mind_wandering,
+            "mental_intention": mental_intention,
+            "mental_notes": mental_notes,
+        }
+
     try:
         if not as_json:
             print("Analyzing run...", file=sys.stderr)
-        feedback = analyze_run_feedback(prescribed, actual, weekly_context, trend_data, benchmark_data, race_info, athlete_targets=targets_dict, nutrition_data=nutrition_data, historical_data=historical_summary)
+        feedback = analyze_run_feedback(prescribed, actual, weekly_context, trend_data, benchmark_data, race_info, athlete_targets=targets_dict, nutrition_data=nutrition_data, historical_data=historical_summary, mental_data=mental_data)
     except Exception as e:
         feedback = {
             "compliance_score": None,
@@ -381,8 +393,9 @@ def _submit_run(distance, duration=None, hr=None, max_hr=None, elevation=None,
                 actual_distance_miles, prescribed_pace, actual_pace, avg_heart_rate,
                 max_heart_rate, elevation_gain_ft, effort_rating, compliance_score,
                 pace_feedback, hr_feedback, overall_feedback, warnings,
-                pre_meal, during_fuel, during_hydration, post_meal, nutrition_notes)
-               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                pre_meal, during_fuel, during_hydration, post_meal, nutrition_notes,
+                mental_state, breathing_quality, mind_wandering, mental_intention, mental_notes)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
             (workout_id, daily_workout_id, plan["id"],
              prescribed.get("target_distance_miles"), distance,
              prescribed.get("target_pace_min_per_mile"), pace,
@@ -392,7 +405,8 @@ def _submit_run(distance, duration=None, hr=None, max_hr=None, elevation=None,
              feedback.get("hr_feedback", ""),
              feedback.get("overall_feedback", ""),
              json.dumps(feedback.get("warnings", [])),
-             pre_meal, during_fuel, during_hydration, post_meal, nutrition_notes),
+             pre_meal, during_fuel, during_hydration, post_meal, nutrition_notes,
+             mental_state, breathing_quality, mind_wandering, mental_intention, mental_notes),
         )
 
     vault_result = None
@@ -403,6 +417,7 @@ def _submit_run(distance, duration=None, hr=None, max_hr=None, elevation=None,
             actual=actual,
             feedback=feedback,
             nutrition=nutrition_data,
+            mental=mental_data,
             weekly_context=weekly_context,
             notes=notes or None,
             as_json=as_json,
@@ -438,7 +453,7 @@ def _summarize_for_product_log(prescribed, actual, feedback):
 
 
 def _write_run_to_vault(*, run_date, prescribed, actual, feedback, nutrition,
-                        weekly_context, notes, as_json):
+                        mental=None, weekly_context, notes, as_json):
     """Write the run report + product log entry, swallowing errors so DB writes succeed.
 
     Returns a dict with status info, or None on hard failure (vault path unset, etc).
@@ -450,6 +465,7 @@ def _write_run_to_vault(*, run_date, prescribed, actual, feedback, nutrition,
             actual=actual,
             feedback=feedback,
             nutrition=nutrition,
+            mental=mental,
             weekly_context=weekly_context,
             notes=notes,
         )
@@ -497,6 +513,9 @@ def cmd_submit(args):
         pre_meal=args.pre_meal, during_fuel=args.during_fuel,
         during_hydration=args.during_hydration, post_meal=args.post_meal,
         nutrition_notes=args.nutrition_notes,
+        mental_state=args.mental_state, breathing_quality=args.breathing_quality,
+        mind_wandering=args.mind_wandering, mental_intention=args.mental_intention,
+        mental_notes=args.mental_notes,
         scheduled_date=getattr(args, 'scheduled_date', None),
         skip_vault=getattr(args, 'no_vault', False),
     )
@@ -521,6 +540,8 @@ def cmd_submit(args):
                 print(f"  - {w}")
         if feedback.get("race_readiness"):
             print(f"\nRace Readiness: {feedback['race_readiness']}")
+        if feedback.get("mental_feedback"):
+            print(f"\nMental: {feedback['mental_feedback']}")
         v = result.get("vault") or {}
         if v.get("path"):
             print(f"\nVault note: {v['path']}")
@@ -709,6 +730,15 @@ def _save_feedback_to_vault(args):
             "post_meal": fb_row.get("post_meal"),
             "nutrition_notes": fb_row.get("nutrition_notes"),
         }
+    mental = None
+    if any(fb_row.get(k) for k in ("mental_state", "breathing_quality", "mind_wandering", "mental_intention", "mental_notes")):
+        mental = {
+            "mental_state": fb_row.get("mental_state"),
+            "breathing_quality": fb_row.get("breathing_quality"),
+            "mind_wandering": fb_row.get("mind_wandering"),
+            "mental_intention": fb_row.get("mental_intention"),
+            "mental_notes": fb_row.get("mental_notes"),
+        }
     weekly_context = None
     if fb_row.get("week_number"):
         weekly_context = {
@@ -718,7 +748,7 @@ def _save_feedback_to_vault(args):
 
     result = _write_run_to_vault(
         run_date=run_date, prescribed=prescribed, actual=actual,
-        feedback=feedback, nutrition=nutrition, weekly_context=weekly_context,
+        feedback=feedback, nutrition=nutrition, mental=mental, weekly_context=weekly_context,
         notes=fb_row.get("workout_notes") or None, as_json=args.json,
     )
 
@@ -2323,6 +2353,15 @@ def main():
     submit_p.add_argument("--during-hydration", type=str, help="During-run hydration")
     submit_p.add_argument("--post-meal", type=str, help="Post-run meal description")
     submit_p.add_argument("--nutrition-notes", type=str, help="Nutrition observations (bonking, GI issues, etc)")
+    submit_p.add_argument("--mental-state", type=str, choices=["calm", "focused", "scattered", "stressed", "flow"],
+                          help="Dominant mental state during the run (issue #9)")
+    submit_p.add_argument("--breathing-quality", type=str, choices=["relaxed", "forced", "erratic"],
+                          help="Breathing quality during the run")
+    submit_p.add_argument("--mind-wandering", type=str, choices=["yes", "no", "sometimes"],
+                          help="Did the mind wander off task/calm during the run?")
+    submit_p.add_argument("--mental-intention", type=str,
+                          help="Pre-run mindset TARGET (e.g. 'box breathing on climbs'); enables prescribed-vs-actual mental tracking")
+    submit_p.add_argument("--mental-notes", type=str, help="Free-text mental/focus observations")
     submit_p.add_argument("--scheduled-date", type=str, help="Date of the prescribed workout if different from --date")
     submit_p.add_argument("--no-vault", action="store_true", help="Skip writing the run report to Obsidian")
     submit_p.add_argument("--json", action="store_true")

--- a/backend/database.py
+++ b/backend/database.py
@@ -167,6 +167,11 @@ def init_db():
                 hr_feedback TEXT,
                 overall_feedback TEXT,
                 warnings TEXT,
+                mental_state TEXT,
+                breathing_quality TEXT,
+                mind_wandering TEXT,
+                mental_intention TEXT,
+                mental_notes TEXT,
                 created_at TEXT NOT NULL DEFAULT (datetime('now'))
             );
 
@@ -365,6 +370,11 @@ def init_db():
         # Add nutrition columns to run_feedback if they don't exist (migration)
         rf_cols = {row[1] for row in conn.execute("PRAGMA table_info(run_feedback)").fetchall()}
         for col in ("pre_meal", "during_fuel", "during_hydration", "post_meal", "nutrition_notes"):
+            if col not in rf_cols:
+                conn.execute(f"ALTER TABLE run_feedback ADD COLUMN {col} TEXT")
+
+        # Add mental-state columns to run_feedback if they don't exist (migration, issue #9 piece 1)
+        for col in ("mental_state", "breathing_quality", "mind_wandering", "mental_intention", "mental_notes"):
             if col not in rf_cols:
                 conn.execute(f"ALTER TABLE run_feedback ADD COLUMN {col} TEXT")
 

--- a/backend/llm.py
+++ b/backend/llm.py
@@ -360,7 +360,8 @@ def analyze_run_feedback(prescribed: dict, actual: dict,
                          race_info: dict | None = None,
                          athlete_targets: dict | None = None,
                          nutrition_data: dict | None = None,
-                         historical_data: dict | None = None) -> dict:
+                         historical_data: dict | None = None,
+                         mental_data: dict | None = None) -> dict:
     """Analyze a completed run against the prescribed workout and return structured feedback."""
 
     system_prompt = """You are an experienced ultramarathon coach analyzing a training run for an athlete preparing for a 100-mile race (Burning River 100, July 25, 2026, sub-24hr goal).
@@ -390,6 +391,19 @@ NUTRITION COACHING:
 - GI issues are common — use training runs to practice nutrition, not race day
 - If athlete reports bonking or GI issues, flag it prominently in feedback
 
+MENTAL ENERGY COACHING (treat as a peer dimension to fitness and economy, not a soft add-on):
+- Mental state and cardiac output are directly coupled: a scattered/stressed mind raises HR at
+  the same pace; calm focus and relaxed breathing lower HR and improve economy. When mental data
+  is provided, read HR-at-pace through this lens before concluding fitness is the limiter.
+- The ultra mental tools are PRE-LOADED then DEPLOYED, not improvised when depleted: rehearsed
+  visualization, pre-written mantras ("Calm is strong"), and pain reframes ("burning quads = info,
+  not a stop sign"). Reinforce practicing these on training runs so they are automatic on race day.
+- If a pre-run mental INTENTION/target was set, coach prescribed-vs-actual: did the athlete hold the
+  intention? If breathing was forced/erratic or the mind wandered, suggest a concrete anchor (box
+  breathing, cadence counting, a present-moment cue) to practice next time.
+- Mile 60-70 is where 100-milers implode; frame calm-under-fatigue as a trainable skill being built now.
+- Keep mental_feedback empty ("") when no mental data was provided.
+
 Respond with JSON only:
 {
     "compliance_score": <0-100 float>,
@@ -398,6 +412,7 @@ Respond with JSON only:
     "distance_feedback": "...",
     "overall_feedback": "...",
     "nutrition_feedback": "...",
+    "mental_feedback": "...",
     "weekly_mileage": {"target": <num>, "completed": <num>, "remaining": <num>},
     "warnings": ["warning1", "warning2"],
     "race_readiness": "On track / Needs attention / Behind"
@@ -419,6 +434,11 @@ Respond with JSON only:
         user_msg_parts.append(f"\n## Current Athlete Targets\n{json.dumps(athlete_targets, indent=2, default=str)}")
     if nutrition_data:
         user_msg_parts.append(f"\n## Nutrition Report\n{json.dumps(nutrition_data, indent=2, default=str)}")
+    if mental_data:
+        user_msg_parts.append(
+            "\n## Mental Report (mental_intention = pre-run TARGET; the rest = how the run actually felt)\n"
+            + json.dumps(mental_data, indent=2, default=str)
+        )
     if historical_data:
         user_msg_parts.append(
             "\n## Historical Race Analysis (athlete's own prior efforts)\n"

--- a/backend/tests/test_vault.py
+++ b/backend/tests/test_vault.py
@@ -52,20 +52,31 @@ class RenderRunReportTests(unittest.TestCase):
                 "hr_feedback": "Z2 throughout.",
                 "warnings": ["Watch hydration tomorrow."],
                 "race_readiness": "On track",
+                "mental_feedback": "Calm focus held HR down — keep practicing box breathing.",
             },
             nutrition={"pre_meal": "oatmeal", "during_fuel": "1 gel"},
+            mental={
+                "mental_state": "calm",
+                "breathing_quality": "relaxed",
+                "mind_wandering": "no",
+                "mental_intention": "box breathing on climbs",
+                "mental_notes": "HR dropped when I focused on breath.",
+            },
             weekly_context={"week_number": 8, "week_type": "build"},
             notes="Felt smooth.",
         )
 
         for header in ("## Easy Run", "## Prescribed", "## Actual", "## Coaching Feedback",
-                       "## Nutrition", "## Notes"):
+                       "## Nutrition", "## Mental", "## Notes"):
             self.assertIn(header, md)
         self.assertIn("Week 8 (build)", md)
         self.assertIn("Compliance Score: 92/100", md)
         self.assertIn("Race Readiness: On track", md)
         self.assertIn("Watch hydration tomorrow.", md)
         self.assertIn("Pre-run: oatmeal", md)
+        self.assertIn("Intention (target): box breathing on climbs", md)
+        self.assertIn("State: calm", md)
+        self.assertIn("Calm focus held HR down", md)
         self.assertTrue(md.endswith("\n"))
 
     def test_omits_sections_with_no_data(self):
@@ -79,6 +90,7 @@ class RenderRunReportTests(unittest.TestCase):
         self.assertNotIn("## Prescribed", md)
         self.assertNotIn("## Coaching Feedback", md)
         self.assertNotIn("## Nutrition", md)
+        self.assertNotIn("## Mental", md)
         self.assertNotIn("## Notes", md)
         self.assertIn("## Actual", md)
 

--- a/backend/vault.py
+++ b/backend/vault.py
@@ -134,14 +134,15 @@ def render_run_report(
     actual: dict | None,
     feedback: dict | None,
     nutrition: dict | None = None,
+    mental: dict | None = None,
     weekly_context: dict | None = None,
     notes: str | None = None,
 ) -> str:
     """Render a run report as markdown.
 
-    Sections: Prescribed, Actual, Coaching Feedback, Nutrition, Notes. Sections with
-    no data are omitted so the output stays readable. Always includes an actual section
-    so the report is never empty.
+    Sections: Prescribed, Actual, Coaching Feedback, Nutrition, Mental, Notes. Sections
+    with no data are omitted so the output stays readable. Always includes an actual
+    section so the report is never empty.
     """
     prescribed = prescribed or {}
     actual = actual or {}
@@ -258,6 +259,29 @@ def render_run_report(
             lines.append(f"_Notes:_ {nutrition['nutrition_notes']}")
         lines.append("")
 
+    # Mental (issue #9)
+    if mental and any(mental.get(k) for k in (
+        "mental_state", "breathing_quality", "mind_wandering", "mental_intention", "mental_notes",
+    )):
+        lines.append("## Mental")
+        lines.append("")
+        if mental.get("mental_intention"):
+            lines.append(f"- Intention (target): {mental['mental_intention']}")
+        if mental.get("mental_state"):
+            lines.append(f"- State: {mental['mental_state']}")
+        if mental.get("breathing_quality"):
+            lines.append(f"- Breathing: {mental['breathing_quality']}")
+        if mental.get("mind_wandering"):
+            lines.append(f"- Mind wandering: {mental['mind_wandering']}")
+        if feedback.get("mental_feedback"):
+            lines.append("")
+            lines.append("### Coaching")
+            lines.append(feedback["mental_feedback"])
+        if mental.get("mental_notes"):
+            lines.append("")
+            lines.append(f"_Notes:_ {mental['mental_notes']}")
+        lines.append("")
+
     if notes:
         lines.append("## Notes")
         lines.append("")
@@ -317,6 +341,7 @@ def write_run_report_to_vault(
     actual: dict | None,
     feedback: dict | None,
     nutrition: dict | None = None,
+    mental: dict | None = None,
     weekly_context: dict | None = None,
     notes: str | None = None,
     description: str | None = None,
@@ -335,7 +360,7 @@ def write_run_report_to_vault(
     workouts_dir = _workouts_dir()  # raises VaultError if env unset/missing
     body = render_run_report(
         run_date=run_date, prescribed=prescribed, actual=actual,
-        feedback=feedback, nutrition=nutrition,
+        feedback=feedback, nutrition=nutrition, mental=mental,
         weekly_context=weekly_context, notes=notes,
     )
 


### PR DESCRIPTION
First of four pieces for **issue #9 — mental training as a first-class dimension**. Treats mental energy management as a peer dimension to fitness and economy: mental state and cardiac output are directly coupled (a scattered mind raises HR at constant pace; calm focus lowers it). Built on the nutrition feature as a template.

## What this adds — capture + AI coaching + vault

Five optional `ultra submit` flags, validated where categorical:
- `--mental-intention` — the pre-run **target** (the "mindset target for runs" idea); enables prescribed-vs-actual mental tracking
- `--mental-state` (calm / focused / scattered / stressed / flow)
- `--breathing-quality` (relaxed / forced / erratic)
- `--mind-wandering` (yes / no / sometimes)
- `--mental-notes` (free text)

```bash
python3 cli.py ultra submit --distance 10 --duration 100 --hr 140 \
  --mental-intention "box breathing on climbs" --mental-state flow \
  --breathing-quality relaxed --mind-wandering no \
  --mental-notes "HR dropped whenever I focused on breath"
```

## Touchpoints
| File | Change |
|---|---|
| `database.py` | 5 new `run_feedback` columns via additive migration (safe on existing DBs) |
| `cli.py` | flags → `cmd_submit` → `_submit_run` → `mental_data` → INSERT; surfaced in submit output + retroactive `feedback --save` path |
| `llm.py` | `mental_data` param + MENTAL ENERGY COACHING principles + `mental_feedback` JSON field + context section |
| `vault.py` | `## Mental` section in run reports |
| `CLAUDE.md` | Mental Training Tracking coaching section + example |

## Coaching lens
Grounded in the 2026 Western States post-race interviews + ultra sport-psych: the mental tools are **pre-loaded then deployed** (rehearsed visualization, pre-written mantras, pain reframes). The AI now reads HR-at-pace through the mental-coupling lens and coaches practicing these on training runs so they're automatic by race day.

## Verification
- 56/56 tests pass (added Mental-section coverage to `test_vault.py`)
- Migration applies cleanly on fresh **and** pre-existing DBs
- Full submit → DB → vault round-trip confirmed (stubbed LLM)

## Remaining pieces of #9 (tracked on the issue)
- [ ] Piece 2 — weekly mental-training prescriptions
- [ ] Piece 3 — race-day mental rehearsal (per-segment cues / dark-patch scripts)
- [ ] Piece 4 — HR-at-pace × mental-state correlation analysis (depends on this captured data)

🤖 Generated with [Claude Code](https://claude.com/claude-code)