### PR TITLE
Add race-day mental rehearsal plan (issue #9, piece 3)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,7 +69,23 @@ Each of the 20 plan weeks carries a **mental-training prescription** alongside i
 
 Surfaced as a **Mental:** line in `ultra today`, `ultra week`, and `TRAINING_PLAN.md`. When coaching a run, tie the athlete's per-run `--mental-intention` back to the week's prescription (prescribed-vs-actual at the week level). After editing prescriptions, re-run `ultra plan --export-md`.
 
-Remaining pieces of #9 (still to build): race-day mental rehearsal (piece 3, per-segment cues / dark-patch scripts in the Race Day Engine + capstone), and HR-at-pace × mental-state correlation analysis in run reports (piece 4, needs ≥~6 runs of piece-1 data).
+### Race-day mental rehearsal (piece 3)
+
+The **mental race plan** (`ultra race mental`) is the deploy-day counterpart to the crew manual: it maps each Race Day Engine segment to a mental **zone** (launch → settle → grind → dark-patch → deep → closer, by mile fraction), overlays **night** (segments whose ETA lands after sunset) and the peer cohort's high-divergence **danger** segments, and renders a printable per-segment "what you'll likely feel here → what to deploy" sheet with clock ETAs. It paces to the governor via the **same spine as the crew manual** (`race_engine.segment_cumulative_seconds`), so both surfaces put you in the same place at the same time.
+
+All athlete-specific content — mantras, reframes, anchors, the pre-race visualization, and the zone scripts — lives in `backend/data/br100_mental_race_plan.yaml` (hand-editable, like `br100_crew_protocol.yaml`; a second race = a second profile). The tools were **pre-loaded** across the 20-week block (`MENTAL_FOCUS`); race day is **deploy, not rehearse**. After editing the profile, just re-run the command.
+
+```bash
+cd /home/michaelpawlus/projects/workout-app/backend
+python3 cli.py ultra race mental --weather-temp 82              # print the plan
+python3 cli.py ultra race mental --vault                        # write to vault race/<Race> Mental Race Plan.md
+python3 cli.py ultra race mental --no-splits                    # engine grade+fade model instead of the 2025 analog
+python3 cli.py ultra race mental --json                         # structured (zones + per-segment cues)
+```
+
+The capstone (`ultra race capstone`) folds a compact mental signal (`signals.mental`: zone arc + dark-patch/night markers + toolkit) into its synthesis order and links the full mental-plan doc, so mental energy is a first-class dimension of the strategy report.
+
+Remaining piece of #9 (still to build): HR-at-pace × mental-state correlation analysis in run reports (piece 4, needs ≥~6 runs of piece-1 data).
 
 ## Schedule Adjustments
 
@@ -216,6 +232,17 @@ python3 cli.py ultra race crew-manual --splits backend/data/br100_2025_analog_sp
 python3 cli.py ultra race crew-manual --no-splits             # use the engine's grade+fade model
 # Defaults: --profile backend/data/br100_crew_protocol.yaml; goal/start from that profile;
 # splits from the bundled 2025 analog. Load the BR100 GPX first for grade-aware ETAs.
+
+# Mental race plan (issue #9, piece 3): per-segment dark-patch / rehearsal script.
+# Maps each segment to a mental zone (by mile fraction), overlays night (ETA past
+# sunset) + the peer cohort's high-divergence segments, and renders a printable
+# "what you'll feel → what to deploy" sheet with clock ETAs. Paces to the governor
+# via the same spine as the crew manual. Athlete content lives in the YAML profile.
+python3 cli.py ultra race mental --weather-temp 82
+python3 cli.py ultra race mental --vault --json           # write into the Obsidian vault (race/)
+python3 cli.py ultra race mental --no-splits              # engine grade+fade model, not the 2025 analog
+# Defaults: --profile backend/data/br100_mental_race_plan.yaml; goal/start/sunset from it;
+# ETAs from the bundled 2025 analog skeleton. Load the BR100 GPX + aid stations first.
 
 # Capstone strategy report (issue #16): the meta-synthesis everything feeds into.
 # Agent-driven (mirrors aggregate-reports/peer-splits): the CLI gathers EVERY internal

--- a/backend/cli.py
+++ b/backend/cli.py
@@ -29,6 +29,7 @@ from . import strava
 from . import race_engine
 from . import race_research
 from . import race_capstone
+from . import race_mental
 from . import peer_splits
 from . import vault
 
@@ -1965,6 +1966,97 @@ def cmd_race_crew_manual(args):
         print(f"Vault write skipped: {saved['vault_error']}", file=sys.stderr)
 
 
+def cmd_race_mental(args):
+    """Mental race plan (#9, piece 3): per-segment dark-patch / rehearsal script.
+
+    Maps each course segment to a mental zone, overlays night + the peer cohort's
+    high-divergence segments, and renders a printable "what you'll feel → what to
+    deploy" plan. Paces to the governor via the same spine as the crew manual.
+    """
+    from pathlib import Path
+    data_dir = Path(__file__).resolve().parent / "data"
+
+    profile_path = args.profile or str(data_dir / "br100_mental_race_plan.yaml")
+    try:
+        profile = race_mental.load_mental_profile(profile_path)
+    except (FileNotFoundError, ValueError) as e:
+        _err(str(e), args.json, 2)
+
+    # Pacing skeleton: explicit --splits, else the bundled analog, unless --no-splits.
+    skeleton = None
+    splits_path = None
+    if not args.no_splits:
+        if args.splits:
+            splits_path = args.splits
+        else:
+            cand = data_dir / "br100_2025_analog_splits.csv"
+            if cand.exists():
+                splits_path = str(cand)
+    if splits_path:
+        try:
+            skeleton = race_engine.load_split_skeleton(splits_path)
+        except (FileNotFoundError, ValueError) as e:
+            _err(str(e), args.json, 2)
+
+    goal_seconds = race_engine._parse_time(args.goal_time) if args.goal_time else None
+
+    with get_db() as conn:
+        course = race_engine.get_course(conn)
+        if not course:
+            _err("No course loaded. Run: ultra race load-course "
+                 "(then load-aid-stations).", args.json, 2)
+
+        # Cohort flags high-divergence segments; failure here just drops the overlay.
+        cohort = None
+        try:
+            cohort = race_engine.analyze_cohort(
+                conn, course["id"],
+                goal_seconds if goal_seconds is not None
+                else race_engine._parse_time(
+                    profile.get("meta", {}).get("governor_goal_time", "26:00:00")),
+            )
+        except Exception:
+            cohort = None
+
+        script = race_mental.build_mental_script(
+            conn, course["id"], profile,
+            goal_time_seconds=goal_seconds,
+            start_time=args.start_time,
+            weather_temp_f=args.weather_temp,
+            skeleton=skeleton,
+            cohort=cohort,
+        )
+
+    md = race_mental.mental_script_to_markdown(script)
+
+    saved = {}
+    if args.output:
+        with open(args.output, "w") as f:
+            f.write(md)
+        saved["output_path"] = args.output
+    if args.vault:
+        try:
+            res = vault.write_mental_plan_to_vault(md, script["course"])
+            saved["vault_path"] = res["path"]
+        except vault.VaultError as e:
+            saved["vault_error"] = str(e)
+
+    if args.json:
+        out = dict(script)
+        if saved:
+            out["saved"] = saved
+        _print(out, True)
+        return
+
+    print(md)
+    if "output_path" in saved:
+        print(f"\nSaved to {saved['output_path']}", file=sys.stderr)
+    if "vault_path" in saved:
+        print(f"Wrote mental race plan to {saved['vault_path']}", file=sys.stderr)
+    if "vault_error" in saved:
+        print(f"Vault write skipped: {saved['vault_error']}", file=sys.stderr)
+
+
 def cmd_race_checkin(args):
     with get_db() as conn:
         # Find the A-plan race_plan_id for the latest course
@@ -2274,6 +2366,15 @@ def cmd_race_capstone(args):
     print(f"  ▸ Race plan A/B/C: {bands}  (base {rp.get('base_pace_display')})")
     print(f"  ▸ Fueling: {len(sig['fueling'])} segments costed")
     print(f"  ▸ Crew/drop-bag stations: {len(sig['crew_stations'])}")
+    mp = sig.get("mental")
+    if mp:
+        dp = mp.get("dark_patch_range")
+        dp_str = f"dark patch ~mi {dp[0]:g}–{dp[1]:g}" if dp else "no dark-patch band"
+        night = mp.get("night_onset_mile")
+        night_str = f", night from mi {night:g}" if night is not None else ""
+        print(f"  ▸ Mental plan: {len(mp.get('zones') or [])} zones, {dp_str}{night_str}")
+    else:
+        print("  ▸ Mental plan: none (profile absent)")
     tb = sig["training_block"]
     print(f"  ▸ Training block: {tb.get('count')} logged runs "
           f"({len(tb.get('long_runs') or [])} long runs ≥18mi), latest {tb.get('latest_date')}")
@@ -2282,7 +2383,7 @@ def cmd_race_capstone(args):
     print("References to read:")
     print(f"  report: {refs.get('report_path')} "
           f"({'EXISTS — update in place' if refs.get('report_exists') else 'new — write fresh'})")
-    for key in ("course_guide", "peer_learnings", "crew_manual", "workouts_dir"):
+    for key in ("course_guide", "peer_learnings", "crew_manual", "mental_plan", "workouts_dir"):
         print(f"  {key}: {refs[key]}")
     print()
 
@@ -2611,6 +2712,27 @@ def main():
     rcm_p.add_argument("--vault", action="store_true", help="Write the manual into the Obsidian vault")
     rcm_p.add_argument("--json", action="store_true")
 
+    # ultra race mental
+    rmt_p = race_sub.add_parser(
+        "mental",
+        help="Mental race plan (#9 piece 3): per-segment dark-patch / rehearsal script")
+    rmt_p.add_argument("--goal-time", type=str,
+                       help="Governor finish time (HH:MM:SS); default from the profile")
+    rmt_p.add_argument("--start-time", type=str,
+                       help="Race start time (HH:MM); default from the profile")
+    rmt_p.add_argument("--weather-temp", type=float,
+                       help="Forecast temperature (°F), shown in the plan header")
+    rmt_p.add_argument("--profile", type=str,
+                       help="Path to the mental race plan YAML (default backend/data/br100_mental_race_plan.yaml)")
+    rmt_p.add_argument("--splits", type=str,
+                       help="Peer-split skeleton CSV to pace ETAs (default: bundled 2025 analog)")
+    rmt_p.add_argument("--no-splits", action="store_true",
+                       help="Ignore the peer skeleton; use the engine's grade+fade model")
+    rmt_p.add_argument("--output", type=str, help="Save markdown to a file path")
+    rmt_p.add_argument("--vault", action="store_true",
+                       help="Write the plan into the Obsidian vault (race/)")
+    rmt_p.add_argument("--json", action="store_true")
+
     # ultra race checkin
     rci_p = race_sub.add_parser("checkin", help="Log arrival at an aid station during race")
     rci_p.add_argument("--station", type=str, required=True,
@@ -2746,6 +2868,7 @@ def main():
                 "aggregate-reports": cmd_race_aggregate_reports,
                 "peer-splits": cmd_race_peer_splits,
                 "capstone": cmd_race_capstone,
+                "mental": cmd_race_mental,
             }
 
             cmd = race_commands.get(args.race_command)

--- a/backend/data/br100_mental_race_plan.yaml
+++ b/backend/data/br100_mental_race_plan.yaml
@@ -1,0 +1,110 @@
+# Burning River 100 — race-day mental rehearsal profile (2026).
+#
+# Issue #9, piece 3: mental energy management is a peer dimension to fitness and
+# economy, so race day gets its own rehearsal script — not a soft add-on. This is
+# the athlete-specific, hand-editable data layer for `ultra race mental`; the engine
+# maps each course segment to a mental ZONE (by mile fraction), overlays night
+# (ETA past sunset) and the peer cohort's high-divergence "danger" segments, and
+# renders a per-segment "what you'll likely feel here → what to deploy" plan.
+#
+# Nothing race-specific is hardcoded in Python (mirrors br100_crew_protocol.yaml):
+# a second race = a second profile. The tools below were PRE-LOADED across the
+# 20-week block (see MENTAL_FOCUS in ultra_plan.py) — race day is DEPLOY, not
+# rehearse. Keep this diff-able and committed.
+
+meta:
+  race: Burning River 100
+  year: 2026
+  athlete: Michael Pawlus
+  start_time: "04:00"            # 4:00 AM gun; drives the day/dusk/night ETA tags
+  governor_goal_time: "26:00:00" # Pace the rehearsal to THIS, not the 24h stretch
+  sunset: "20:50"                # Akron, late July — segments reached after = night
+  sunrise: "06:15"               # second sunrise, ~mile 90+ for a 26h day
+
+# The trained toolkit. Repeated through the block so it's automatic under fatigue.
+mantras:
+  - "Calm is strong."
+  - "One aid station at a time."
+  - "Patient, present, fueling on schedule."
+  - "Relentless forward progress."
+
+# Pain/discomfort reframes — turn a stop signal into information.
+reframes:
+  quads: "Burning quads = information, not a stop sign. Note it, keep moving."
+  low_mood: "The low is chemical, not the truth. Eat, drink, and it lifts."
+  doubt: "Doubt shows up on schedule around mile 60. It's a visitor, not a verdict."
+  heat: "Heat is the #1 challenge — respect it: cool, slow, and it stays survivable."
+  clock: "Beating the 26h ETAs is confidence. Chasing 24 is stress. Run the governor."
+
+# Present-moment anchors — where attention goes when the mind wanders to fatigue.
+anchors:
+  - "Footstrike / cadence — count 20 steps."
+  - "Breath: in 3, out 2."
+  - "Body scan: jaw → shoulders → hands → hips, release."
+  - "Name three things you can see right now."
+
+# Pre-race visualization sequence — rehearse the night before and at the start line.
+# Bank composure, not time; see yourself calm exactly where it usually gets hard.
+visualization:
+  - "The 4 AM start: calm and patient in the dark, letting the fast starters go."
+  - "Every crew stop: quick, cheerful, fueled — in and out, ETA beaten."
+  - "The mile 60–70 low arriving on schedule — and you already know the script."
+  - "Nightfall with the headlamp: the world shrinks to the trail; you settle in."
+  - "The final towpath miles: legs shot, mind quiet, reeling in the finish."
+
+# Zone scripts — the engine maps segments to these by mile fraction of the course.
+# Order matters only for display; `max_fraction` is the upper bound of each zone.
+zones:
+  launch:
+    max_fraction: 0.20
+    label: "Launch — patience"
+    likely_feel: "Fresh and eager in the cool dark; tempted to bank time early."
+    do: "Let the field go. Run an effort you'd barely notice. Fuel from mile one."
+    deploy: "Bank composure, not time."
+  settle:
+    max_fraction: 0.45
+    label: "Settle — find the rhythm"
+    likely_feel: "Warming up, into a groove; the day is getting real but you're fine."
+    do: "Lock the fueling clock (gel every 30–40 min). Relaxed jaw and shoulders."
+    deploy: "Patient, present, fueling on schedule."
+  grind:
+    max_fraction: 0.58
+    label: "Grind — the work begins"
+    likely_feel: "First real fatigue, heat of the day, halfway math starting to bite."
+    do: "Down-shift, cool aggressively, walk the climbs. Keep eating before hungry."
+    deploy: "One aid station at a time."
+    reframe: heat
+  dark_patch:
+    max_fraction: 0.70
+    label: "Dark patch — the low"
+    likely_feel: "The famous mile 60–70 implosion: low mood, doubt, 'why am I here'."
+    do: >-
+      Shrink the race to the next aid station only. Eat, drink, keep moving —
+      the low is chemical and it WILL pass. Do not make any big decision here.
+    deploy: "This will pass. It always passes. Next aid station only."
+    reframe: low_mood
+  deep:
+    max_fraction: 0.85
+    label: "Deep water — past the low"
+    likely_feel: "Through the worst, but deep fatigue and (likely) full dark now."
+    do: "Relentless forward progress. Power-hike the ups, jog the flats/downs."
+    deploy: "Relentless forward progress."
+    reframe: quads
+  closer:
+    max_fraction: 1.01
+    label: "Closer — bring it home"
+    likely_feel: "Legs shot, but the finish is real and pulling you in."
+    do: "Empty the tank on your terms. Reel in the miles one at a time; smile."
+    deploy: "Calm is strong — finish the way you rehearsed."
+
+# Overlays stack ON TOP of the mile-fraction zone for a given segment.
+overlays:
+  night:
+    label: "Night"
+    likely_feel: "World shrinks to the headlamp cone; time and pace get slippery."
+    do: >-
+      Settle into the quiet. Chase your own light. Extra vigilance on fuel —
+      it's easy to forget to eat in the dark.
+    deploy: "Chase the light. Keep eating."
+  cohort_danger:
+    note: "Peers scatter here (high split variance) — hold your plan while others unravel."

--- a/backend/race_capstone.py
+++ b/backend/race_capstone.py
@@ -31,7 +31,11 @@ from . import vault
 from .adapt import get_current_targets
 
 
-_DEFAULT_MENTAL_PROFILE = Path(__file__).resolve().parent / "data" / "br100_mental_race_plan.yaml"
+_DATA_DIR = Path(__file__).resolve().parent / "data"
+_DEFAULT_MENTAL_PROFILE = _DATA_DIR / "br100_mental_race_plan.yaml"
+# Same peer-split skeleton the standalone `ultra race mental` / crew manual pace off
+# by default, so the dossier's mental signal matches the linked artifact's ETAs.
+_DEFAULT_MENTAL_SKELETON = _DATA_DIR / "br100_2025_analog_splits.csv"
 
 
 def _mental_signal(
@@ -53,10 +57,25 @@ def _mental_signal(
         return None
     try:
         profile = race_mental.load_mental_profile(str(_DEFAULT_MENTAL_PROFILE))
+        # Pace the signal off the profile's OWN start time (falling back to the
+        # capstone's only if the profile lacks one), so the dossier's night/dark-
+        # patch clocks match the linked Mental Race Plan artifact — which is
+        # profile-driven and ignores the capstone default. Otherwise the capstone's
+        # 05:00 default would shift night_onset_mile an hour off the doc it cites.
+        mental_start = profile.get("meta", {}).get("start_time") or start_time
+        # Pace off the same bundled skeleton the artifact uses (fall back to the
+        # engine model if it's absent), so ETAs — and thus night/dark-patch miles —
+        # line up with the linked Mental Race Plan.
+        skeleton = None
+        if _DEFAULT_MENTAL_SKELETON.exists():
+            try:
+                skeleton = race_engine.load_split_skeleton(str(_DEFAULT_MENTAL_SKELETON))
+            except (FileNotFoundError, ValueError):
+                skeleton = None
         script = race_mental.build_mental_script(
             conn, course_id, profile,
-            goal_time_seconds=goal_time_seconds, start_time=start_time,
-            weather_temp_f=weather_temp_f, cohort=cohort,
+            goal_time_seconds=goal_time_seconds, start_time=mental_start,
+            weather_temp_f=weather_temp_f, skeleton=skeleton, cohort=cohort,
         )
     except Exception:
         return None

--- a/backend/race_capstone.py
+++ b/backend/race_capstone.py
@@ -21,12 +21,67 @@ Public surface:
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Any
 
 from . import race_engine
 from . import historical
+from . import race_mental
 from . import vault
 from .adapt import get_current_targets
+
+
+_DEFAULT_MENTAL_PROFILE = Path(__file__).resolve().parent / "data" / "br100_mental_race_plan.yaml"
+
+
+def _mental_signal(
+    conn,
+    course_id: int,
+    goal_time_seconds: int,
+    start_time: str,
+    weather_temp_f: float | None,
+    cohort: dict | None,
+) -> dict[str, Any] | None:
+    """Compact mental race-plan signal (issue #9, piece 3) for the dossier.
+
+    Loads the bundled mental profile, builds the per-segment script (reusing the
+    already-computed ``cohort`` for danger flags), and collapses it to the zone arc
+    + dark-patch/night markers + the trained toolkit. Returns ``None`` if the
+    profile is absent/unreadable so the capstone still builds without it.
+    """
+    if not _DEFAULT_MENTAL_PROFILE.exists():
+        return None
+    try:
+        profile = race_mental.load_mental_profile(str(_DEFAULT_MENTAL_PROFILE))
+        script = race_mental.build_mental_script(
+            conn, course_id, profile,
+            goal_time_seconds=goal_time_seconds, start_time=start_time,
+            weather_temp_f=weather_temp_f, cohort=cohort,
+        )
+    except Exception:
+        return None
+
+    # Collapse the per-segment plan into consecutive-zone bands for the dossier.
+    zones: list[dict[str, Any]] = []
+    for seg in script["segments"]:
+        if zones and zones[-1]["zone"] == seg["zone"]:
+            zones[-1]["end_mile"] = seg["end_mile"]
+        else:
+            zones.append({
+                "zone": seg["zone"],
+                "label": seg["zone_label"],
+                "start_mile": seg["start_mile"],
+                "end_mile": seg["end_mile"],
+                "deploy": seg["deploy"],
+            })
+
+    return {
+        "dark_patch_range": script["dark_patch_range"],
+        "night_onset_mile": script["night_onset_mile"],
+        "mantras": script["mantras"],
+        "reframes": script["reframes"],
+        "zones": zones,
+    }
 
 
 DEFAULT_TARGET_FINISH = "26:00:00"
@@ -96,6 +151,7 @@ def _vault_references(course_name: str, title: str) -> dict[str, Any]:
         "course_guide": f"race-prep/{course_name} Course & Strategy Guide.md",
         "peer_learnings": f"race-prep/{course_name} Peer Split Learnings.md",
         "crew_manual": f"race/{course_name} Crew Manual.md",
+        "mental_plan": f"race/{course_name} Mental Race Plan.md",
         "workouts_dir": "workouts/  (per-run narrative + Mohican benchmark report)",
         "product_log": "workouts/PRODUCT_LOG.md",
         "memory": "Workout App memory: Mohican benchmark, fueling protocol, course guide notes.",
@@ -133,6 +189,11 @@ def _output_sections() -> list[dict[str, str]]:
          "what": "Explicit if/then plans. Anchor on the Canal Corridor weather-DNF lesson: "
                  "do NOT let bad overnight weather end the race mentally. Heat, GI, dark-"
                  "patch, and behind-pace playbooks."},
+        {"heading": "Mental Race Plan & Dark-Patch Scripts",
+         "what": "Mental energy as the third lever (issue #9): the zone-by-zone arc from "
+                 "`signals.mental` — patience early, the mile ~60–70 dark-patch script, the "
+                 "night overlay — with the mantras/reframes to deploy. Tie it to the crew "
+                 "plan (crew reads mood at each stop) and flag where peers scatter."},
         {"heading": "Lessons Integrated",
          "what": "Trace each pacing/fueling decision back to its signal — own-history fade, "
                  "peer cohort, Mohican benchmark, training block — so the plan is auditable."},
@@ -164,6 +225,9 @@ def _method(existing: bool) -> list[str]:
         "(`signals.peer_cohort.slowdown_pct`); call out the danger-zone segments explicitly.",
         "Cross-check the fueling schedule against the athlete's logged protocol and the Mohican "
         "HEED lesson — do not invent products; reconcile g/hr and mg/hr against `signals.fueling`.",
+        "Weave the mental race plan in as a first-class dimension: pull the zone arc + dark-patch "
+        "script + night overlay from `signals.mental` (full detail in the linked mental-plan doc), "
+        "and align the mantras/reframes to the clock ETAs so the low patch has a rehearsed response.",
         "Keep every claim traceable to a signal in this dossier or a cited vault doc; flag any "
         "gap the data cannot close rather than papering over it.",
         "Save with `ultra race capstone --save-guide -` (markdown on stdin) — stable filename, so "
@@ -230,6 +294,10 @@ def build_capstone_dossier(
         if s.get("crew_accessible") or s.get("drop_bag")
     ]
 
+    # --- mental race plan (issue #9, piece 3) -----------------------------
+    mental = _mental_signal(
+        conn, course_id, goal_time_seconds, start_time, weather_temp_f, cohort)
+
     # --- training block digest --------------------------------------------
     training_block = _training_block_digest(conn, plan_id)
 
@@ -270,6 +338,7 @@ def build_capstone_dossier(
             "race_plan": race_plan,
             "fueling": fueling,
             "crew_stations": crew_stations,
+            "mental": mental,
             "training_block": training_block,
         },
         "references": references,

--- a/backend/race_engine.py
+++ b/backend/race_engine.py
@@ -1220,6 +1220,42 @@ def eta_seconds_from_skeleton(skeleton, mile, course_total_miles, goal_seconds):
     return raw * (goal_seconds / total_s)
 
 
+def segment_cumulative_seconds(conn, course_id, segments, total_miles,
+                               goal_time_seconds, start_time="05:00",
+                               weather_temp_f=None, skeleton=None):
+    """Cumulative elapsed seconds at each segment's END mile, paced to the governor.
+
+    Shared pacing spine for the crew manual (#12) and the mental race plan (#9,
+    piece 3), so both surfaces put the athlete at the same place at the same clock
+    time. ETAs come from ``skeleton`` (a peer-split pacing skeleton scaled to the
+    goal) when provided; otherwise from the engine's goal-pace race plan, whose
+    grade/fade SHAPE is normalized so the finish pins exactly to the governor.
+
+    Returns ``({segment_number: seconds}, eta_source_label)``.
+    """
+    if skeleton:
+        cum_by_num = {
+            s["segment_number"]: eta_seconds_from_skeleton(
+                skeleton, s["end_mile"], total_miles, goal_time_seconds)
+            for s in segments
+        }
+        return cum_by_num, "peer-split skeleton"
+
+    # Engine fallback: force GOAL-based pacing (plan_id=None) so ETAs honor the
+    # governor rather than the athlete's current training targets, then normalize
+    # the grade+fatigue curve so its total pins to the goal.
+    race_plan = generate_race_plan(
+        conn, course_id, None, goal_time_seconds,
+        weather_temp_f=weather_temp_f, start_time=start_time,
+    )
+    gov = race_plan["plans"]["A"]["segments"]
+    raw_cum = {s["segment_number"]: s["cumulative_time_seconds"] for s in gov}
+    engine_total = race_plan["plans"]["A"]["total_time_seconds"]
+    scale = goal_time_seconds / engine_total if engine_total else 1.0
+    cum_by_num = {num: secs * scale for num, secs in raw_cum.items()}
+    return cum_by_num, "engine model (grade + fade), scaled to governor"
+
+
 def _sodium_per_hr(protocol, hot):
     """Resolve the working sodium rate (mg/hr) from the profile, hot-aware."""
     fueling = protocol.get("fueling", {})
@@ -1261,35 +1297,11 @@ def generate_crew_manual(conn, course_id, protocol, goal_time_seconds=None,
     total_miles = course["total_distance_miles"] if course else 0
 
     # Cumulative elapsed seconds at each segment's end mile, from either source.
-    if skeleton:
-        cum_by_num = {
-            s["segment_number"]: eta_seconds_from_skeleton(
-                skeleton, s["end_mile"], total_miles, goal_time_seconds)
-            for s in segments
-        }
-        eta_source = "peer-split skeleton"
-        gov_finish_display = _format_time(goal_time_seconds)
-    else:
-        # Engine fallback: force GOAL-based pacing so the manual's ETAs honor the
-        # governor. Passing the active plan id would make generate_race_plan base
-        # pace on the athlete's *current training* targets (long_run_pace) instead,
-        # letting ETAs/fuel/night-kit timing drift off the advertised governor.
-        # (The skeleton path above already scales the curve to the goal.)
-        race_plan = generate_race_plan(
-            conn, course_id, None, goal_time_seconds,
-            weather_temp_f=weather_temp_f, start_time=start_time,
-        )
-        gov = race_plan["plans"]["A"]["segments"]
-        raw_cum = {s["segment_number"]: s["cumulative_time_seconds"] for s in gov}
-        # generate_race_plan starts from goal pace but layers grade/fatigue/heat
-        # multipliers, so its total drifts past the goal. Normalize the curve to
-        # the governor — keep the grade+fade SHAPE, pin the finish to goal — so the
-        # fallback honors the advertised governor just like the skeleton path.
-        engine_total = race_plan["plans"]["A"]["total_time_seconds"]
-        scale = goal_time_seconds / engine_total if engine_total else 1.0
-        cum_by_num = {num: secs * scale for num, secs in raw_cum.items()}
-        eta_source = "engine model (grade + fade), scaled to governor"
-        gov_finish_display = _format_time(goal_time_seconds)
+    cum_by_num, eta_source = segment_cumulative_seconds(
+        conn, course_id, segments, total_miles, goal_time_seconds,
+        start_time=start_time, weather_temp_f=weather_temp_f, skeleton=skeleton,
+    )
+    gov_finish_display = _format_time(goal_time_seconds)
 
     hot_threshold = (protocol.get("cooling") or {}).get("hot_threshold_f")
     hot = (weather_temp_f is not None and hot_threshold is not None

--- a/backend/race_mental.py
+++ b/backend/race_mental.py
@@ -1,0 +1,324 @@
+"""Race-day mental rehearsal — the mental race plan (issue #9, piece 3).
+
+Mental energy management is a peer dimension to fitness and economy (issue #9), so
+race day gets its own rehearsal artifact rather than a soft footnote. This module
+maps each course segment of the Race Day Engine to a mental **zone** (by mile
+fraction of the course), overlays **night** (segments whose ETA lands after sunset)
+and the peer cohort's high-divergence **danger** segments, and renders a
+per-segment "what you'll likely feel here → what to deploy" plan.
+
+Design mirrors the crew manual (``race_engine.generate_crew_manual``): all the
+athlete-specific content — mantras, reframes, anchors, the pre-race visualization,
+and the zone scripts — lives in a hand-editable YAML profile
+(``data/br100_mental_race_plan.yaml``); nothing race-specific is hardcoded here, so
+a second race is a second profile. Pacing (and therefore the clock/night tags) uses
+the SAME spine as the crew manual (``race_engine.segment_cumulative_seconds``), so
+both surfaces put the athlete in the same place at the same time.
+
+Public surface:
+
+- ``load_mental_profile(path)`` — parse + validate the YAML profile.
+- ``build_mental_script(conn, course_id, profile, ...)`` — the structured plan.
+- ``mental_script_to_markdown(script)`` — printable / vault markdown.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+from . import race_engine
+
+
+# Sections/keys a usable profile must carry (fail loudly, like load_crew_protocol).
+_REQUIRED_TOP = ["zones"]
+
+
+def load_mental_profile(path: str) -> dict:
+    """Load and validate a race-day mental rehearsal profile (YAML).
+
+    Returns the parsed dict. Raises ``FileNotFoundError`` if the file is missing and
+    ``ValueError`` if it is malformed or missing the ``zones`` map, so a broken
+    profile fails with a clear message rather than rendering an empty plan.
+    """
+    try:
+        import yaml
+    except ImportError as exc:  # pragma: no cover - dep declared in requirements
+        raise ValueError(
+            "PyYAML is required to read mental race plan profiles "
+            "(`pip install pyyaml`)."
+        ) from exc
+
+    p = Path(path)
+    if not p.exists():
+        raise FileNotFoundError(f"Mental race plan profile not found: {path}")
+
+    with p.open(encoding="utf-8") as f:
+        data = yaml.safe_load(f) or {}
+
+    if not isinstance(data, dict):
+        raise ValueError(f"Mental race plan profile is not a mapping: {path}")
+
+    for key in _REQUIRED_TOP:
+        if not isinstance(data.get(key), dict) or not data[key]:
+            raise ValueError(
+                f"Mental race plan profile {path} is missing required section: {key}"
+            )
+    return data
+
+
+def _zone_for_fraction(zones: dict, frac: float) -> tuple[str, dict]:
+    """Pick the zone whose ``max_fraction`` first covers ``frac``.
+
+    Zones are considered in ascending ``max_fraction`` order so the profile can list
+    them in any order. Falls back to the last (highest) zone for the finish.
+    """
+    ordered = sorted(zones.items(), key=lambda kv: kv[1].get("max_fraction", 1.0))
+    for key, zone in ordered:
+        if frac <= zone.get("max_fraction", 1.0):
+            return key, zone
+    key, zone = ordered[-1]
+    return key, zone
+
+
+def build_mental_script(
+    conn,
+    course_id: int,
+    profile: dict,
+    *,
+    goal_time_seconds: int | None = None,
+    start_time: str | None = None,
+    weather_temp_f: float | None = None,
+    skeleton: dict | None = None,
+    cohort: dict | None = None,
+) -> dict[str, Any]:
+    """Build a per-segment mental race plan paced to the governor.
+
+    Walks the course segments, classifies each into a mental zone by mile fraction,
+    overlays night (ETA past the profile's ``sunset``) and cohort danger segments,
+    and attaches the zone's script (likely feel / what to do / cue to deploy) plus
+    any referenced reframe. ``cohort`` is an optional ``analyze_cohort`` result used
+    only to flag high-divergence segments — pace does not depend on it.
+
+    Returns a JSON-serializable dict ready for ``mental_script_to_markdown``.
+    """
+    meta = profile.get("meta", {})
+    zones = profile.get("zones", {})
+    reframes = profile.get("reframes", {})
+    overlays = profile.get("overlays", {})
+
+    if goal_time_seconds is None:
+        goal_time_seconds = race_engine._parse_time(
+            meta.get("governor_goal_time", "26:00:00"))
+    if start_time is None:
+        start_time = meta.get("start_time", "05:00")
+
+    course = race_engine.get_course(conn, course_id)
+    segments = race_engine.get_segments(conn, course_id)
+    total_miles = course["total_distance_miles"] if course else 0
+
+    cum_by_num, eta_source = race_engine.segment_cumulative_seconds(
+        conn, course_id, segments, total_miles, goal_time_seconds,
+        start_time=start_time, weather_temp_f=weather_temp_f, skeleton=skeleton,
+    )
+
+    start_dt = datetime.strptime(start_time, "%H:%M")
+    sunset_dt = race_engine._clock_on_day(meta.get("sunset"), start_dt)
+    sunrise_dt = race_engine._clock_on_day(meta.get("sunrise"), start_dt)
+    # Second sunrise lands on race day + 1 for an overnight finish.
+    sunrise_next = sunrise_dt + timedelta(days=1) if sunrise_dt else None
+
+    # Peer cohort high-divergence ("danger") segments, if a cohort was supplied.
+    danger_nums = set()
+    if cohort:
+        for cs in cohort.get("segments", []):
+            if cs.get("danger_zone"):
+                danger_nums.add(cs["segment_number"])
+
+    plan_segments = []
+    night_onset_mile = None
+    dark_patch_miles: list[float] = []
+    for seg in segments:
+        mid_mile = (seg["start_mile"] + seg["end_mile"]) / 2
+        frac = mid_mile / total_miles if total_miles else 0
+        zone_key, zone = _zone_for_fraction(zones, frac)
+
+        cumulative = cum_by_num.get(seg["segment_number"], 0)
+        eta_dt = start_dt + timedelta(seconds=cumulative)
+
+        # Night = arrival between sunset and the next sunrise.
+        is_night = False
+        if sunset_dt and eta_dt >= sunset_dt:
+            is_night = sunrise_next is None or eta_dt < sunrise_next
+        if is_night and night_onset_mile is None:
+            night_onset_mile = round(seg["end_mile"], 1)
+
+        is_danger = seg["segment_number"] in danger_nums
+        if zone_key == "dark_patch":
+            dark_patch_miles.append(round(seg["end_mile"], 1))
+
+        reframe_key = zone.get("reframe")
+        entry = {
+            "segment_number": seg["segment_number"],
+            "station_name": seg.get("name") or f"Mile {seg['end_mile']:.1f}",
+            "start_mile": round(seg["start_mile"], 1),
+            "end_mile": round(seg["end_mile"], 1),
+            "eta_clock": race_engine._eta_clock(eta_dt, start_dt),
+            "eta_elapsed": race_engine._format_time(cumulative),
+            "zone": zone_key,
+            "zone_label": zone.get("label", zone_key),
+            "likely_feel": zone.get("likely_feel"),
+            "do": zone.get("do"),
+            "deploy": zone.get("deploy"),
+            "reframe": reframes.get(reframe_key) if reframe_key else None,
+            "night": is_night,
+            "cohort_danger": is_danger,
+        }
+        plan_segments.append(entry)
+
+    dark_patch_range = None
+    if dark_patch_miles:
+        lo = min(dark_patch_miles)
+        # low end of the first dark-patch segment for a truthful "miles X–Y"
+        lo_seg = next((e for e in plan_segments if e["zone"] == "dark_patch"), None)
+        if lo_seg:
+            lo = lo_seg["start_mile"]
+        dark_patch_range = (lo, max(dark_patch_miles))
+
+    return {
+        "course": course["name"] if course else "Unknown",
+        "total_miles": total_miles,
+        "start_time": start_time,
+        "governor_goal_display": race_engine._format_time(goal_time_seconds),
+        "weather_temp_f": weather_temp_f,
+        "eta_source": eta_source,
+        "sunset": meta.get("sunset"),
+        "sunrise": meta.get("sunrise"),
+        "night_onset_mile": night_onset_mile,
+        "dark_patch_range": dark_patch_range,
+        "cohort_size": cohort.get("cohort_size") if cohort else 0,
+        "mantras": profile.get("mantras") or [],
+        "reframes": reframes,
+        "anchors": profile.get("anchors") or [],
+        "visualization": profile.get("visualization") or [],
+        "overlays": overlays,
+        "meta": meta,
+        "segments": plan_segments,
+    }
+
+
+def mental_script_to_markdown(script: dict) -> str:
+    """Render a mental race plan dict as printable / vault markdown."""
+    s = script
+    L: list[str] = []
+
+    L.append(f"# {s['course']} — Mental Race Plan "
+             f"({s['governor_goal_display']} governor)")
+    L.append("")
+    L.append(f"**Start:** {s['start_time']} · **Total:** {s['total_miles']} miles")
+    if s.get("weather_temp_f") is not None:
+        L.append(f"**Forecast:** {s['weather_temp_f']}°F")
+    tags = []
+    if s.get("night_onset_mile") is not None:
+        tags.append(f"night from ~mile {s['night_onset_mile']}")
+    if s.get("dark_patch_range"):
+        lo, hi = s["dark_patch_range"]
+        tags.append(f"dark patch ~miles {lo:g}–{hi:g}")
+    if tags:
+        L.append("*" + " · ".join(tags) + f" · ETAs from {s['eta_source']}.*")
+    else:
+        L.append(f"*ETAs from {s['eta_source']}.*")
+    L.append("")
+    L.append("> Mental energy is the third lever alongside fitness and economy. "
+             "You **pre-loaded** these tools across the block — race day is "
+             "**deploy, not rehearse**. Calm is strong.")
+    L.append("")
+
+    # --- The trained toolkit -------------------------------------------------
+    if s["mantras"]:
+        L.append("## Mantras")
+        L.append("")
+        for m in s["mantras"]:
+            L.append(f"- {m}")
+        L.append("")
+
+    if s["reframes"]:
+        L.append("## Reframes")
+        L.append("")
+        for _, text in s["reframes"].items():
+            L.append(f"- {text}")
+        L.append("")
+
+    if s["anchors"]:
+        L.append("## Anchors (where attention goes when the mind wanders)")
+        L.append("")
+        for a in s["anchors"]:
+            L.append(f"- {a}")
+        L.append("")
+
+    if s["visualization"]:
+        L.append("## Pre-race visualization")
+        L.append("")
+        L.append("*Rehearse the night before and at the start line — see yourself "
+                 "calm exactly where it usually gets hard.*")
+        L.append("")
+        for v in s["visualization"]:
+            L.append(f"1. {v}")
+        L.append("")
+
+    # --- Segment-by-segment rehearsal ---------------------------------------
+    # Zone guidance is stated once per zone; the aid stations under it carry their
+    # own ETA + overlay flags. This keeps the sheet skimmable at the aid station.
+    L.append("## Segment-by-segment")
+    L.append("")
+    L.append("*You move through the zones below in order. Each zone's cue applies to "
+             "every aid station listed under it — read it as you come in.*")
+    L.append("")
+
+    last_zone = None
+    for e in s["segments"]:
+        if e["zone"] != last_zone:
+            if L and L[-1] != "":
+                L.append("")  # blank line before a new zone heading
+            L.append(f"### {e['zone_label']}")
+            L.append("")
+            if e["likely_feel"]:
+                L.append(f"*Likely feel:* {e['likely_feel']}")
+                L.append("")
+            if e["do"]:
+                L.append(f"- **Do:** {e['do']}")
+            L.append(f"- **Deploy:** {e['deploy']}")
+            if e["reframe"]:
+                L.append(f"- **Reframe:** *{e['reframe']}*")
+            L.append("")
+            L.append("Aid stations:")
+            last_zone = e["zone"]
+
+        flags = []
+        if e["night"]:
+            flags.append("🌙 night")
+        if e["cohort_danger"]:
+            flags.append("⚠ peers scatter here")
+        flag_str = f" — {', '.join(flags)}" if flags else ""
+
+        L.append(f"- Mile {e['end_mile']:g} · {e['station_name']} "
+                 f"(~{e['eta_clock']}, {e['eta_elapsed']} elapsed){flag_str}")
+    L.append("")
+
+    # --- Overlays as standing reminders -------------------------------------
+    overlays = s.get("overlays") or {}
+    night_ov = overlays.get("night")
+    if night_ov and s.get("night_onset_mile") is not None:
+        L.append(f"## When it gets dark (~mile {s['night_onset_mile']:g})")
+        L.append("")
+        if night_ov.get("likely_feel"):
+            L.append(f"*Likely feel:* {night_ov['likely_feel']}")
+            L.append("")
+        if night_ov.get("do"):
+            L.append(f"- Do: {night_ov['do']}")
+        if night_ov.get("deploy"):
+            L.append(f"- Deploy: **{night_ov['deploy']}**")
+        L.append("")
+
+    return "\n".join(L).rstrip() + "\n"

--- a/backend/tests/test_capstone.py
+++ b/backend/tests/test_capstone.py
@@ -91,7 +91,7 @@ class CapstoneTestCase(unittest.TestCase):
         sig = dossier["signals"]
         self.assertEqual(set(sig), {
             "targets", "history", "peer_cohort", "race_plan",
-            "fueling", "crew_stations", "training_block"})
+            "fueling", "crew_stations", "mental", "training_block"})
 
         # History wired through.
         self.assertEqual(sig["history"]["count"], 1)

--- a/backend/tests/test_race_mental.py
+++ b/backend/tests/test_race_mental.py
@@ -286,6 +286,22 @@ class CapstoneMentalSignalTestCase(unittest.TestCase):
         headings = [s["heading"] for s in dossier["output_sections"]]
         self.assertTrue(any("Mental Race Plan" in h for h in headings))
 
+    def test_mental_signal_paces_off_profile_start_not_capstone_default(self):
+        # The mental signal must match the (profile-driven) Mental Race Plan doc it
+        # links, regardless of the start time the capstone is invoked with — so its
+        # night/dark-patch clocks don't drift an hour off the artifact.
+        with database.get_db() as conn:
+            course = dict(self.race_engine.get_course(conn))
+            early = self.race_capstone.build_capstone_dossier(
+                conn, course, plan_id=None,
+                goal_time_seconds=26 * 3600, start_time="04:00",
+            )["signals"]["mental"]
+            late = self.race_capstone.build_capstone_dossier(
+                conn, course, plan_id=None,
+                goal_time_seconds=26 * 3600, start_time="12:00",
+            )["signals"]["mental"]
+        self.assertEqual(early["night_onset_mile"], late["night_onset_mile"])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/backend/tests/test_race_mental.py
+++ b/backend/tests/test_race_mental.py
@@ -1,0 +1,291 @@
+"""Tests for the race-day mental rehearsal plan (issue #9, piece 3).
+
+Run with: ``python3 -m unittest backend.tests.test_race_mental -v`` from repo root.
+
+Uses a throwaway SQLite file + a synthetic GPX course, so real data is never touched.
+Mirrors the crew-manual test harness (they share the pacing spine).
+"""
+
+from __future__ import annotations
+
+import math
+import os
+import tempfile
+import textwrap
+import unittest
+from unittest.mock import patch
+
+from backend import database
+
+
+def _write_synthetic_gpx(path, n=200, lat0=40.0, lon0=-81.5):
+    pts = []
+    for i in range(n + 1):
+        lat = lat0 + i * 0.0009
+        ele = 300 + 200 * math.sin(math.pi * i / n)
+        pts.append(f'<trkpt lat="{lat:.6f}" lon="{lon0:.6f}"><ele>{ele:.1f}</ele></trkpt>')
+    gpx = (
+        '<?xml version="1.0" encoding="UTF-8"?>\n'
+        '<gpx version="1.1" creator="test"><trk><trkseg>\n'
+        + "\n".join(pts)
+        + "\n</trkseg></trk></gpx>\n"
+    )
+    with open(path, "w") as f:
+        f.write(gpx)
+
+
+MENTAL_YAML = textwrap.dedent("""
+    meta:
+      race: Test Course
+      start_time: "04:00"
+      governor_goal_time: "26:00:00"
+      sunset: "20:50"
+      sunrise: "06:15"
+    mantras:
+      - "Calm is strong."
+    reframes:
+      low_mood: "The low is chemical, not the truth."
+      heat: "Respect the heat."
+    anchors:
+      - "In 3, out 2."
+    visualization:
+      - "See the calm start."
+    zones:
+      launch:
+        max_fraction: 0.20
+        label: "Launch"
+        likely_feel: "Fresh and eager."
+        do: "Let the field go."
+        deploy: "Bank composure, not time."
+      settle:
+        max_fraction: 0.55
+        label: "Settle"
+        likely_feel: "Into a groove."
+        do: "Lock the fueling clock."
+        deploy: "Patient, present."
+      dark_patch:
+        max_fraction: 0.72
+        label: "Dark patch"
+        likely_feel: "The famous low."
+        do: "Next aid station only."
+        deploy: "This will pass."
+        reframe: low_mood
+      closer:
+        max_fraction: 1.01
+        label: "Closer"
+        likely_feel: "Finish pulling you in."
+        do: "Empty the tank."
+        deploy: "Calm is strong."
+    overlays:
+      night:
+        label: "Night"
+        likely_feel: "World shrinks to the headlamp."
+        do: "Chase the light."
+        deploy: "Keep eating."
+      cohort_danger:
+        note: "Peers scatter here."
+""")
+
+
+class RaceMentalTestCase(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+        self._tmp.close()
+        self._patcher = patch.object(database, "DB_PATH", self._tmp.name)
+        self._patcher.start()
+        database.init_db()
+
+        self._gpx = tempfile.NamedTemporaryFile(suffix=".gpx", delete=False)
+        self._gpx.close()
+        _write_synthetic_gpx(self._gpx.name)
+
+        from backend import race_engine, race_mental
+        self.race_engine = race_engine
+        self.race_mental = race_mental
+
+        with database.get_db() as conn:
+            cid, segs, total, gain = race_engine.load_course(
+                conn, self._gpx.name, "Test Course", 2026,
+            )
+            stations = [
+                {"mile": round(total * 0.25, 2), "name": "Quarter",
+                 "crew": True, "drop_bag": False, "notes": "close 9:00 AM"},
+                {"mile": round(total * 0.50, 2), "name": "Half",
+                 "crew": True, "drop_bag": True, "notes": "close noon"},
+                {"mile": round(total * 0.65, 2), "name": "TwoThirds",
+                 "crew": True, "drop_bag": False, "notes": "close 5:00 PM"},
+                {"mile": round(total * 0.90, 2), "name": "Nine",
+                 "crew": True, "drop_bag": False, "notes": "close 3:00 AM"},
+                {"mile": round(total, 2), "name": "Finish",
+                 "crew": True, "drop_bag": True, "notes": "close 10:00 AM"},
+            ]
+            race_engine.import_aid_stations(conn, stations, course_id=cid)
+        self.course_id = cid
+        self.total = total
+
+        self._profile_file = tempfile.NamedTemporaryFile(
+            suffix=".yaml", delete=False, mode="w")
+        self._profile_file.write(MENTAL_YAML)
+        self._profile_file.close()
+
+        self._splits_file = tempfile.NamedTemporaryFile(
+            suffix=".csv", delete=False, mode="w")
+        self._splits_file.write(
+            "mile,name,elapsed\n"
+            "12.1,A,2:29:13\n"
+            "50.3,Half,11:05:24\n"
+            "100.5,Finish,26:39:43\n"
+        )
+        self._splits_file.close()
+
+    def tearDown(self):
+        self._patcher.stop()
+        for f in (self._tmp.name, self._gpx.name,
+                  self._profile_file.name, self._splits_file.name):
+            os.unlink(f)
+
+    def _profile(self):
+        return self.race_mental.load_mental_profile(self._profile_file.name)
+
+    def _build(self, **kw):
+        with database.get_db() as conn:
+            return self.race_mental.build_mental_script(
+                conn, self.course_id, self._profile(), **kw)
+
+    # -- profile loader ------------------------------------------------------
+
+    def test_load_profile_ok(self):
+        p = self._profile()
+        self.assertEqual(p["meta"]["start_time"], "04:00")
+        self.assertIn("dark_patch", p["zones"])
+
+    def test_load_profile_missing_zones_raises(self):
+        bad = tempfile.NamedTemporaryFile(suffix=".yaml", delete=False, mode="w")
+        bad.write("meta:\n  start_time: '04:00'\n")  # no zones
+        bad.close()
+        try:
+            with self.assertRaises(ValueError) as ctx:
+                self.race_mental.load_mental_profile(bad.name)
+            self.assertIn("zones", str(ctx.exception))
+        finally:
+            os.unlink(bad.name)
+
+    def test_load_profile_missing_file_raises(self):
+        with self.assertRaises(FileNotFoundError):
+            self.race_mental.load_mental_profile("/no/such/mental.yaml")
+
+    # -- zone classification -------------------------------------------------
+
+    def test_zone_for_fraction_boundaries(self):
+        zones = self._profile()["zones"]
+        self.assertEqual(self.race_mental._zone_for_fraction(zones, 0.05)[0], "launch")
+        self.assertEqual(self.race_mental._zone_for_fraction(zones, 0.20)[0], "launch")
+        self.assertEqual(self.race_mental._zone_for_fraction(zones, 0.30)[0], "settle")
+        self.assertEqual(self.race_mental._zone_for_fraction(zones, 0.66)[0], "dark_patch")
+        self.assertEqual(self.race_mental._zone_for_fraction(zones, 0.99)[0], "closer")
+
+    # -- build_mental_script -------------------------------------------------
+
+    def test_every_segment_gets_a_zone_and_cue(self):
+        script = self._build()
+        self.assertTrue(script["segments"])
+        for e in script["segments"]:
+            self.assertIn(e["zone"], self._profile()["zones"])
+            self.assertTrue(e["deploy"])
+
+    def test_dark_patch_zone_present_and_carries_reframe(self):
+        script = self._build()
+        dark = [e for e in script["segments"] if e["zone"] == "dark_patch"]
+        self.assertTrue(dark, "expected a dark-patch band on a 100mi course")
+        self.assertTrue(all(e["reframe"] for e in dark))
+        lo, hi = script["dark_patch_range"]
+        self.assertLess(lo, hi)
+
+    def test_skeleton_pins_finish_to_governor(self):
+        sk = self.race_engine.load_split_skeleton(self._splits_file.name)
+        script = self._build(skeleton=sk)
+        # last segment cumulative == governor goal (26h) exactly
+        self.assertEqual(script["segments"][-1]["eta_elapsed"], "26:00:00")
+        self.assertEqual(script["eta_source"], "peer-split skeleton")
+
+    def test_night_overlay_flags_late_segments(self):
+        sk = self.race_engine.load_split_skeleton(self._splits_file.name)
+        script = self._build(skeleton=sk)
+        self.assertIsNotNone(script["night_onset_mile"])
+        # early segments are daylight; some late segment is night
+        self.assertFalse(script["segments"][0]["night"])
+        self.assertTrue(any(e["night"] for e in script["segments"]))
+
+    def test_cohort_danger_overlay(self):
+        fake_cohort = {
+            "cohort_size": 5,
+            "segments": [
+                {"segment_number": 1, "danger_zone": True},
+                {"segment_number": 2, "danger_zone": False},
+            ],
+        }
+        script = self._build(cohort=fake_cohort)
+        seg1 = next(e for e in script["segments"] if e["segment_number"] == 1)
+        seg2 = next(e for e in script["segments"] if e["segment_number"] == 2)
+        self.assertTrue(seg1["cohort_danger"])
+        self.assertFalse(seg2["cohort_danger"])
+
+    # -- markdown ------------------------------------------------------------
+
+    def test_markdown_has_core_sections_and_cues(self):
+        sk = self.race_engine.load_split_skeleton(self._splits_file.name)
+        md = self.race_mental.mental_script_to_markdown(self._build(skeleton=sk))
+        self.assertIn("# Test Course — Mental Race Plan", md)
+        self.assertIn("## Mantras", md)
+        self.assertIn("## Pre-race visualization", md)
+        self.assertIn("### Dark patch", md)
+        self.assertIn("This will pass.", md)
+        self.assertIn("🌙 night", md)
+
+
+class CapstoneMentalSignalTestCase(unittest.TestCase):
+    """The capstone dossier should fold in the bundled mental signal (issue #9 piece 3)."""
+
+    def setUp(self):
+        self._tmp = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+        self._tmp.close()
+        self._patcher = patch.object(database, "DB_PATH", self._tmp.name)
+        self._patcher.start()
+        database.init_db()
+
+        self._gpx = tempfile.NamedTemporaryFile(suffix=".gpx", delete=False)
+        self._gpx.close()
+        _write_synthetic_gpx(self._gpx.name)
+
+        from backend import race_engine, race_capstone
+        self.race_engine = race_engine
+        self.race_capstone = race_capstone
+
+        with database.get_db() as conn:
+            cid, segs, total, gain = race_engine.load_course(
+                conn, self._gpx.name, "Test Course", 2026,
+            )
+        self.course_id = cid
+
+    def tearDown(self):
+        self._patcher.stop()
+        for f in (self._tmp.name, self._gpx.name):
+            os.unlink(f)
+
+    def test_dossier_includes_mental_signal(self):
+        with database.get_db() as conn:
+            course = dict(self.race_engine.get_course(conn))
+            dossier = self.race_capstone.build_capstone_dossier(
+                conn, course, plan_id=None,
+                goal_time_seconds=26 * 3600, start_time="04:00",
+            )
+        mental = dossier["signals"]["mental"]
+        self.assertIsNotNone(mental, "bundled mental profile should be found")
+        self.assertTrue(mental["zones"])
+        self.assertIn("mental_plan", dossier["references"])
+        headings = [s["heading"] for s in dossier["output_sections"]]
+        self.assertTrue(any("Mental Race Plan" in h for h in headings))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/vault.py
+++ b/backend/vault.py
@@ -421,6 +421,23 @@ def write_crew_manual_to_vault(markdown: str, race: str, *, subdir: str = "race"
     return {"path": str(target)}
 
 
+def write_mental_plan_to_vault(markdown: str, race: str, *, subdir: str = "race") -> dict:
+    """Write a generated mental race plan into ``<vault>/race/`` as
+    ``<Race> Mental Race Plan.md``.
+
+    Direct write (the plan owns its own markdown); raises ``VaultError`` if
+    ``OBSIDIAN_VAULT_PATH`` is unusable. Returns ``{"path": <absolute md path>}``.
+    Companion to the crew manual (issue #9, piece 3 alongside #12).
+    """
+    out = _vault_root() / subdir
+    out.mkdir(parents=True, exist_ok=True)
+    safe = re.sub(r"\s+", " ", f"{race} Mental Race Plan").strip()
+    safe = re.sub(r'[\\/:*?"<>|]', "", safe)
+    target = out / f"{safe}.md"
+    target.write_text(markdown, encoding="utf-8")
+    return {"path": str(target)}
+
+
 def append_product_log_entry(
     *,
     run_date: str,


### PR DESCRIPTION
Closes piece 3 of #9 (mental training as a first-class dimension). Mental energy is treated as a peer dimension to fitness and economy, so race day gets its own deploy-day artifact — the **mental race plan**, the mental counterpart to the crew manual (#12).

## What this adds

**`ultra race mental`** maps each Race Day Engine segment to a mental **zone** by mile fraction (launch → settle → grind → **dark-patch** → deep → closer), overlays **night** (segments whose ETA lands after sunset) and the peer cohort's high-divergence **danger** segments, and renders a printable per-segment *"likely feel → deploy this cue"* sheet with clock ETAs. On BR100 the dark patch lands ~mile 61–71 (the canonical 60–70 implosion window); night from ~mile 75.

```bash
python3 -m backend.cli ultra race mental --weather-temp 82     # print the plan
python3 -m backend.cli ultra race mental --vault               # write to race/<Race> Mental Race Plan.md
python3 -m backend.cli ultra race mental --no-splits --json    # engine grade+fade model, structured out
```

## Design

Deterministic engine-rendered (crew-manual pattern), not an agent research order — piece 3 is *pre-built, printable, deploy-on-race-day* content. All athlete-specific content (mantras, reframes, anchors, pre-race visualization, zone scripts) lives in `backend/data/br100_mental_race_plan.yaml`, hand-editable and mirroring `br100_crew_protocol.yaml`; a second race = a second profile.

## Files

- `backend/data/br100_mental_race_plan.yaml` — athlete mental profile
- `backend/race_mental.py` — `load_mental_profile` / `build_mental_script` / `mental_script_to_markdown`
- `backend/race_engine.py` — extracted `segment_cumulative_seconds` (the crew-manual pacing spine); `generate_crew_manual` now calls it, so both surfaces share one pacing curve (same place, same time)
- `backend/vault.py` — `write_mental_plan_to_vault`
- `backend/cli.py` — `cmd_race_mental` + argparse
- `backend/race_capstone.py` — folds a compact `signals.mental` into the dossier, adds `references.mental_plan`, a "Mental Race Plan & Dark-Patch Scripts" output section, and a method step
- Tests: `backend/tests/test_race_mental.py` (11); `test_capstone.py` signal-set assertion updated
- CLAUDE.md documents the command + design

## Testing

Full suite: 74 pass (+11 new). Verified `--json`, `--vault`, `--no-splits`, and capstone integration against the loaded BR100 course.

🤖 Generated with [Claude Code](https://claude.com/claude-code)