### PR TITLE
Reconcile race goal to 26h governor across plan/coaching/CLI (#29)

### DIFF
--- a/TRAINING_PLAN.md
+++ b/TRAINING_PLAN.md
@@ -1,6 +1,6 @@
 # Burning River 100 — 20-Week Training Plan
 
-**Goal:** Sub-24 hour finish
+**Goal:** 26-hour finish (target); prior 100s 25:23-27:17
 **Race Date:** July 25, 2026
 **Start:** 2026-03-09 | **End:** 2026-07-26
 
@@ -678,5 +678,5 @@ Target: 10-110 miles
 > Very easy 2mi. Stay loose. Hydrate well.
 
 **2026-07-25 — BURNING RIVER 100**
-> 100 miles. Sub-24 goal = ~14:24/mi avg including all stops. Start conservative. Walk all uphills. Eat early and often. The race starts at mile 60.
+> 100 miles. 26h governor = ~15:36/mi avg including all stops (sub-24 stretch = ~14:24/mi). Start conservative. Walk all uphills. Eat early and often. The race starts at mile 60.
 

--- a/backend/cli.py
+++ b/backend/cli.py
@@ -107,12 +107,13 @@ def cmd_init(args):
                 print(f"Deleted existing plan (id={plan_id})", file=sys.stderr)
 
         plan_id = create_br100_plan(conn)
+        plan = _get_plan(conn)
 
     result = {"plan_id": plan_id, "message": "Burning River 100 plan created"}
     if not args.json:
         print(f"Created Burning River 100 plan (id={plan_id})")
         print("20 weeks: Mar 9 - Jul 26, 2026 (Mon-Sun weeks)")
-        print("Goal: Sub-24 hours")
+        print(f"Goal: {plan['goal']}")
     else:
         _print(result, True)
 
@@ -343,7 +344,7 @@ def _submit_run(distance, duration=None, hr=None, max_hr=None, elevation=None,
         race_info = {
             "race": "Burning River 100",
             "date": "2026-07-25",
-            "goal": "Sub-24 hours",
+            "goal": plan["goal"],
             "weeks_remaining": max(0, (datetime(2026, 7, 25) - datetime.now()).days // 7),
         }
 
@@ -814,7 +815,7 @@ def cmd_progress(args):
         "plan_id": plan["id"],
         "race": "Burning River 100",
         "race_date": "2026-07-25",
-        "goal": "Sub-24 hours",
+        "goal": plan["goal"],
         "weeks_remaining": weeks_remaining,
         "workouts_total": total,
         "workouts_completed": completed,
@@ -827,7 +828,7 @@ def cmd_progress(args):
         _print(result, True)
     else:
         print(f"=== Burning River 100 Progress ===")
-        print(f"Race: July 25, 2026 | Goal: Sub-24hr | Weeks left: {weeks_remaining}")
+        print(f"Race: July 25, 2026 | Goal: {plan['goal']} | Weeks left: {weeks_remaining}")
         print(f"Workouts: {completed}/{total} ({result['completion_pct']}%)")
         print()
         bm_done = sum(1 for b in result["benchmarks"] if b["completed"])

--- a/backend/llm.py
+++ b/backend/llm.py
@@ -364,7 +364,7 @@ def analyze_run_feedback(prescribed: dict, actual: dict,
                          mental_data: dict | None = None) -> dict:
     """Analyze a completed run against the prescribed workout and return structured feedback."""
 
-    system_prompt = """You are an experienced ultramarathon coach analyzing a training run for an athlete preparing for a 100-mile race (Burning River 100, July 25, 2026, sub-24hr goal).
+    system_prompt = """You are an experienced ultramarathon coach analyzing a training run for an athlete preparing for a 100-mile race (Burning River 100, July 25, 2026). The goal is finish-primary: a 26-hour finish is the governor the whole plan paces to; sub-24 is a stretch only.
 
 COACHING PRINCIPLES:
 - 80/20 rule: 80% of runs should be easy (conversational pace), 20% quality (tempo/hills/intervals)

--- a/backend/main.py
+++ b/backend/main.py
@@ -622,7 +622,7 @@ def ultra_submit(req: UltraSubmit):
         race_info = {
             "race": "Burning River 100",
             "date": "2026-07-25",
-            "goal": "Sub-24 hours",
+            "goal": plan["goal"],
             "weeks_remaining": max(0, (datetime(2026, 7, 25) - datetime.now()).days // 7),
         }
 
@@ -742,7 +742,7 @@ def ultra_progress():
         "plan_id": plan["id"],
         "race": "Burning River 100",
         "race_date": "2026-07-25",
-        "goal": "Sub-24 hours",
+        "goal": plan["goal"],
         "weeks_remaining": weeks_remaining,
         "workouts_total": total,
         "workouts_completed": completed,

--- a/backend/ultra_plan.py
+++ b/backend/ultra_plan.py
@@ -9,6 +9,17 @@ from .database import get_db
 from .adapt import seed_initial_targets
 
 
+# --- Canonical race goal (single source of truth: training_plans.goal) ---
+# Post-Mohican recalibration (issue #29): 26h finish is the *governor* the whole
+# plan paces to; sub-24 is a stretch only. race_capstone.py already treats 26h as
+# canonical — these keep the plan/coaching/CLI layers agreeing with it rather than
+# hardcoding "sub-24". Readers should pull training_plans.goal (persisted from these
+# on seed) instead of hardcoding a goal string.
+RACE_GOAL = "26-hour finish (target); prior 100s 25:23-27:17"
+RACE_GOAL_NOTES = ("20-week plan for Burning River 100 (July 25, 2026). "
+                   "Finish-primary: 26h governor; sub-24 is a stretch only.")
+
+
 # Week definitions: (week_num, phase/week_type, target_miles_low, target_miles_high, focus)
 WEEKS = [
     (1,  "base",     25, 30, "Baseline week. Easy running, 5K TT, MAF test"),
@@ -367,9 +378,9 @@ def _race_week(start_date, d):
                 "scheduled_date": day.strftime("%Y-%m-%d"),
                 "workout_type": "race",
                 "title": "BURNING RIVER 100",
-                "description": ("100 miles. Sub-24 goal = ~14:24/mi avg including all stops. "
-                                "Start conservative. Walk all uphills. Eat early and often. "
-                                "The race starts at mile 60."),
+                "description": ("100 miles. 26h governor = ~15:36/mi avg including all stops "
+                                "(sub-24 stretch = ~14:24/mi). Start conservative. Walk all "
+                                "uphills. Eat early and often. The race starts at mile 60."),
                 "target_distance_miles": 100,
                 "intensity": "hard",
                 "is_benchmark": True,
@@ -489,9 +500,8 @@ def create_br100_plan(conn=None, start_date="2026-03-09"):
         cursor = conn.execute(
             """INSERT INTO training_plans (name, goal, start_date, end_date, total_weeks, mesocycle_weeks, status, notes)
                VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
-            ("Burning River 100", "Sub-24 hour finish", start_date,
-             end.strftime("%Y-%m-%d"), 20, 4, "active",
-             "20-week plan for Burning River 100 (July 25, 2026). Target: sub-24 hours."),
+            ("Burning River 100", RACE_GOAL, start_date,
+             end.strftime("%Y-%m-%d"), 20, 4, "active", RACE_GOAL_NOTES),
         )
         plan_id = cursor.lastrowid
 


### PR DESCRIPTION
Closes #29.

The Race Day Engine already treats **26h as the governor** (sub-24 a stretch only), but the training-plan layer, the coaching prompt, and the CLI/status still hardcoded **sub-24** — even a single plan row contradicted itself (`goal` recalibrated to 26h, `notes` still said "Target: sub-24 hours"). This makes the whole app agree with `race_capstone.py`.

## Changes
- **Single source of truth** — added canonical `RACE_GOAL` / `RACE_GOAL_NOTES` constants in `ultra_plan.py`; `create_br100_plan()` seeds both so a freshly-created plan is internally consistent (26h governor, sub-24 framed as stretch).
- **Race-day pacing** — recomputed the race-day workout description to the 26h governor (`~15:36/mi`), with sub-24 (`~14:24/mi`) as the stretch. Fixed in code and in the stored `daily_workouts` row of the live plan.
- **Coaching prompt** — `llm.py` reframed as finish-primary (26h governor, sub-24 stretch).
- **CLI + API read from the plan row** — `cli.py` (init print, `race_info`, progress JSON, status line) and `main.py` (run-report `race_info`, progress endpoint) now read `training_plans.goal` instead of hardcoding `"Sub-24 hours"`.
- **Live DB** — fixed `notes` so it no longer contradicts `goal`.
- **Regenerated `TRAINING_PLAN.md`** — header and race-day pacing line now agree.

## Acceptance criteria
- [x] Canonical representation = DB `training_plans.goal`; code reads it rather than hardcoding
- [x] `create_br100_plan()` seed (`goal` + `notes`) internally consistent
- [x] Live DB `notes` fixed
- [x] Race-day workout description pacing updated to the 26h governor
- [x] Coaching system prompt updated to finish-primary framing
- [x] CLI/`main.py` goal strings read from the plan row
- [x] `TRAINING_PLAN.md` regenerated; header + race-day pacing agree

## Verification
- All edited modules import cleanly; fresh-seed `goal`+`notes` confirmed consistent.
- `ultra progress` (human + `--json`) now shows the 26h goal from the DB.
- Codebase sweep: no remaining hardcoded `Sub-24`/`14:24` outside `race_capstone.py` (already canonical) and the intentional "sub-24 stretch" framing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)